### PR TITLE
Export IoBlock_activate on Windows

### DIFF
--- a/libs/iovm/source/IoBlock.h
+++ b/libs/iovm/source/IoBlock.h
@@ -39,7 +39,7 @@ void IoBlock_message_(IoBlock *self, IoMessage *m);
 
 // calling
 
-IoObject *IoBlock_activate(IoBlock *self, IoObject *target, IoObject *locals, IoMessage *m, IoObject *slotContext);
+IOVM_API IoObject *IoBlock_activate(IoBlock *self, IoObject *target, IoObject *locals, IoMessage *m, IoObject *slotContext);
 IO_METHOD(IoBlock, print);
 
 UArray *IoBlock_justCode(IoBlock *self);


### PR DESCRIPTION
Marked IoBlock_activate with IOVM_API so that it will be exported from the DLL on Windows.  I need this function in order to evaluate Io blocks from C++, and trying to use IoObject_activate instead seems to only return the block object and not the result of calling the block.
