### PR TITLE
Fix linking of UUID

### DIFF
--- a/addons/UUID/CMakeLists.txt
+++ b/addons/UUID/CMakeLists.txt
@@ -32,7 +32,7 @@ if(UUID_FOUND)
 	# Now build the shared library
 	add_library(IoUUID SHARED ${SRCS})
 	add_dependencies(IoUUID iovmall)
-	target_link_libraries(IoUUID iovmall)
+	target_link_libraries(IoUUID iovmall uuid)
 
 	# Install the addon to our global addons hierarchy.
 	install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR} DESTINATION lib/io/addons)


### PR DESCRIPTION
The UUID addon builds as long as the header file is found, but it doesn't link to the uuid library. So when I tried to actually call 'UUID' I was getting an error:

```
Exception: Error loading object '/usr/local/lib/io/addons/UUID/_build/dll/libIoUUID.so': '/usr/local/lib/io/addons/UUID/_build/dll/libIoUUID.so: undefined symbol: uuid_generate'
---------
open                                AddonLoader.io 71
Object UUID                          Command Line 1
```

This merge should fix the problem.
