### PR TITLE
Stupid change made it in a month or so ago, affected everyone.

### DIFF
--- a/addons/CMakeLists.txt
+++ b/addons/CMakeLists.txt
@@ -102,7 +102,9 @@ add_subdirectory(SQLite3)
 #add_subdirectory(SampleRateConverter)
 add_subdirectory(SecureSocket)
 #add_subdirectory(SkipDB) # XXX: Disabled...why?
-#add_subdirectory(Socket)
+if(${CMAKE_SYSTEM_NAME} MATCHES "OpenBSD") # This hsould not be disabled for any platform. Upgrade Socket to support libevent2
+  add_subdirectory(Socket)
+endif(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
 #add_subdirectory(SoundTouch) # XXX: I can't meet dependencies
 add_subdirectory(SqlDatabase)
 add_subdirectory(Syslog)


### PR DESCRIPTION
Remove some of the braindeadness that was disabling Socket by default. Was disabled for OpenBSD before, but affected everyone. proper check is now in place.

NOTE: THIS IS NOT A LONG TERM SOLUTION
We need to get off our royal asses and update the Socket addon to support the libevent2 API, and we needed to do that yesterday.
