### PR TITLE
Jeremy's commit fd3fd962 needed minor correction.

### DIFF
--- a/addons/CMakeLists.txt
+++ b/addons/CMakeLists.txt
@@ -102,9 +102,9 @@ add_subdirectory(SQLite3)
 #add_subdirectory(SampleRateConverter)
 add_subdirectory(SecureSocket)
 #add_subdirectory(SkipDB) # XXX: Disabled...why?
-if(${CMAKE_SYSTEM_NAME} MATCHES "OpenBSD") # This hsould not be disabled for any platform. Upgrade Socket to support libevent2
+if(NOT ${CMAKE_SYSTEM_NAME} MATCHES "OpenBSD") # This should not be disabled for any platform. Upgrade Socket to support libevent2
   add_subdirectory(Socket)
-endif(${CMAKE_SYSTEM_NAME} MATCHES "OpenBSD")
+endif(NOT ${CMAKE_SYSTEM_NAME} MATCHES "OpenBSD")
 #add_subdirectory(SoundTouch) # XXX: I can't meet dependencies
 add_subdirectory(SqlDatabase)
 add_subdirectory(Syslog)


### PR DESCRIPTION
In CMakeLists.txt he made Socket compile only on OpenBSD, rather than on every platform but OpenBSD. Was just missing a NOT.

See http://tech.groups.yahoo.com/group/iolanguage/message/12855 on the group for details.
