### PR TITLE
Define inlined methods only once on Mac.

### DIFF
--- a/libs/basekit/source/Common_inline.h
+++ b/libs/basekit/source/Common_inline.h
@@ -42,11 +42,11 @@ Kudos to Daniel A. Koepke
 	#ifdef IO_IN_C_FILE
 		// in .c 
 		#define IO_DECLARE_INLINES
-		#define IOINLINE 
+		#define IOINLINE inline
 	#else
 		// in .h 
 		#define IO_DECLARE_INLINES
-		#define IOINLINE inline
+		#define IOINLINE extern inline
 	#endif 
 #elif defined(__MINGW32__)
 	#ifdef IO_IN_C_FILE


### PR DESCRIPTION
Fixes #120.

The functions from List_inline.h are included in List.c and Stack.c, defining each symbol twice. On Linux, the definition in Stack.c is marked 'extern', but for some reason, this isn't applied when compiling on the Mac.
