### PR TITLE
Fix compilation of ObjcBridge on OS X 10.5.8 

### DIFF
--- a/addons/ObjcBridge/source/IoObjcBridge.m
+++ b/addons/ObjcBridge/source/IoObjcBridge.m
@@ -449,7 +449,7 @@ IoObject *IoObjcBridge_ioValueForCValue_ofType_error_(IoObjcBridge *self, void *
 			}
 			else if (!strncmp(cType, "{CGSize=dd}", 11))
 			{
-				CGSize s = *(NSSize *)cValue;
+				CGSize s = *(CGSize *)cValue;
 				vec2f v;
 				v.x = s.width;
 				v.y = s.height;


### PR DESCRIPTION
The union variable `cValue` of type `cValue_tag` was first cast to `NSSize` and then assigned to a variable of type `CGSize` which resulted in the following error:

```
IoObjcBridge.m:452: error: invalid initializer
```

This patch fixes this problem.
