### PR TITLE
Fix build for OpenBSD i386.

### DIFF
--- a/addons/CMakeLists.txt
+++ b/addons/CMakeLists.txt
@@ -17,9 +17,10 @@ if(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
 	set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -flat_namespace")
 endif(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
 
-# OpenBSD needs /usr/local/lib and /usr/lib searched
+# Packages are installed under /usr/local on OpenBSD
 if(${CMAKE_SYSTEM_NAME} MATCHES "OpenBSD")
-	set(CMAKE_SHARED_LINKER_FLAGS "-L/usr/local/lib -L/usr/lib ${CMAKE_SHARED_LINKER_FLAGS}")
+	set(CMAKE_C_FLAGS  "-I/usr/local/include ${CMAKE_SHARED_LINKER_FLAGS}")
+	set(CMAKE_SHARED_LINKER_FLAGS "-L/usr/local/lib ${CMAKE_SHARED_LINKER_FLAGS}")
 endif(${CMAKE_SYSTEM_NAME} MATCHES "OpenBSD")
 
 

--- a/libs/basekit/source/Common_inline.h
+++ b/libs/basekit/source/Common_inline.h
@@ -108,7 +108,7 @@ Kudos to Daniel A. Koepke
 		#define IOINLINE static inline
 	#endif 
 	
-#elif defined(__linux__)
+#elif defined(__linux__) || defined(__OpenBSD__) || defined(__NetBSD__) || defined(__FreeBSD__)
 
 	#ifdef IO_IN_C_FILE
 		// in .c 


### PR DESCRIPTION
Also define inline macros for NetBSD and FreeBSD, which I presume work the the same way. 
