### PR TITLE
addons/Socket: allow abstract unix path sockets on Linux

### DIFF
--- a/addons/Socket/source/IoUnixPath.c
+++ b/addons/Socket/source/IoUnixPath.c
@@ -69,8 +69,10 @@ void IoUnixPath_free(IoUnixPath *self)
 IoObject *IoUnixPath_setPath(IoUnixPath *self, IoObject *locals, IoMessage *m)
 {
 #if !defined(_WIN32) || defined(__CYGWIN__)
-	char *pathString = IoSeq_asCString(IoMessage_locals_seqArgAt_(m, locals, 0));
-	UnixPath_setPath_(UNIXPATH(self), pathString);
+  IoObject * path = IoMessage_locals_seqArgAt_(m, locals, 0);
+	char *pathString = IoSeq_asCString(path);
+	size_t pathlen = IoSeq_rawSizeInBytes(path);
+	UnixPath_setPath_(UNIXPATH(self), pathString, pathlen);
 	return self;
 #else
 	return IOSYMBOL("Sorry, no Unix Domain sockets on Windows MSCRT");
@@ -80,7 +82,9 @@ IoObject *IoUnixPath_setPath(IoUnixPath *self, IoObject *locals, IoMessage *m)
 IoObject *IoUnixPath_path(IoUnixPath *self, IoObject *locals, IoMessage *m)
 {
 #if !defined(_WIN32) || defined(__CYGWIN__)
-	return IOSYMBOL(UnixPath_path(UNIXPATH(self)));
+  size_t pathlen;
+  char* path = UnixPath_path(UNIXPATH(self), &pathlen);
+  return IoState_symbolWithCString_length_(IOSTATE, path, pathlen);
 #else
 	return IOSYMBOL("Sorry, no Unix Domain sockets on Windows MSCRT");
 #endif

--- a/addons/Socket/source/UnixPath.h
+++ b/addons/Socket/source/UnixPath.h
@@ -41,7 +41,7 @@ void UnixPath_setSize_(UnixPath *self, socklen_t size);
 
 uint16_t UnixPath_family(UnixPath *self);
 
-void UnixPath_setPath_(UnixPath *self, char *path);
-char *UnixPath_path(UnixPath *self);
+void UnixPath_setPath_(UnixPath *self, char *path, size_t pathlen);
+char *UnixPath_path(UnixPath *self, size_t *pathlen);
 
 #endif


### PR DESCRIPTION
The UnixPath socket type was updated to allow path containing NUL
characters. This is very useful to connect to abstract unix sockets on
Linux, where the path start with a NUL character.
