### PR TITLE
Object addTrait should require at least one argument.

### DIFF
--- a/libs/iovm/io/A0_Object.io
+++ b/libs/iovm/io/A0_Object.io
@@ -1,5 +1,7 @@
 //doc Object addTrait Takes another object, whose slots will be copied into the receiver. Optionally takes a second argument, a Map object containing string -> string pairs, holding conflicting slot names and names to rename them to. I.e., if you have two objects A and B, both have a slot named foo, you issue A addTrait(B, Map clone atPut("foo", "newFoo")) the value of B foo will be placed in A newFoo.
 Object addTrait := method(obj,
+  if(call message arguments size == 0, 
+    Exception raise("addTrait requires at least one argument"))
   resolutions := call evalArgAt(1)
   if(resolutions isNil, resolutions = Map clone)
 

--- a/libs/iovm/tests/correctness/TraitsTest.io
+++ b/libs/iovm/tests/correctness/TraitsTest.io
@@ -21,4 +21,8 @@ TraitsTest := UnitTest clone do(
     assertEquals(42, B fooFromA)
     assertEquals(23, B foo)
   )
+
+  testMissingArguments := method(
+    assertRaisesException(A addTrait)
+  )
 )


### PR DESCRIPTION
This reduces confusion about the behavior of "Foo addTrait".
If someone really wants to add nil as a trait to Foo,
it should be done explicitly.

Reviewed by jer.
