### PR TITLE
"System sleep(s)" not worked properly for s >= 1 second

### DIFF
--- a/libs/iovm/source/IoSystem.c
+++ b/libs/iovm/source/IoSystem.c
@@ -478,6 +478,11 @@ IO_METHOD(IoObject, sleep)
 
 	double seconds = IoMessage_locals_doubleArgAt_(m, locals, 0);
 	unsigned int microseconds = (seconds * 1000000);
+	while (microseconds > 999999)
+	{
+	    usleep(999999);
+	    microseconds -= 999999;
+	}
 	usleep(microseconds);
 	return self;
 }


### PR DESCRIPTION
usleep work with maximum value 999999

System sleep(5) - no wait any time :(
System sleep(1) - no wait
System sleep(0.999) - wait 1 second :)

closed my issue
