### PR TITLE
Make Object 'do' work the same as 'lexicalDo'.

### DIFF
--- a/libs/iovm/source/IoObject.c
+++ b/libs/iovm/source/IoObject.c
@@ -178,6 +178,7 @@ IoObject *IoObject_protoFinish(void *state)
 	{"print", IoObject_lobbyPrint},
 	{"do", IoObject_do},
 	{"lexicalDo", IoObject_lexicalDo},
+	{"nonlexicalDo", IoObject_do},
 	{"message", IoObject_message},
 	{"doMessage", IoObject_doMessage},
 	{"doString", IoObject_doString},
@@ -1801,10 +1802,14 @@ IO_METHOD(IoObject, uniqueId)
 	//return IONUMBER((double)((size_t)IoObject_deref(self)));
 }
 
-IO_METHOD(IoObject, do)
+IO_METHOD(IoObject, nonlexicalDo)
 {
-	/*doc Object do(expression)
-	Evaluates the message in the context of the receiver. Returns self.
+	/*doc Object nonlexicalDo(expression)
+	Evaluates the message in the context of the receiver.
+	The lexical context (locals defined in the calling context)
+	is not visible within the "nonlexicalDo" construct.
+	See "do"/"lexicalDo" for one that does use local context.
+	Returns self.
 	*/
 
 	if (IoMessage_argCount(m) != 0)
@@ -1820,7 +1825,9 @@ IO_METHOD(IoObject, lexicalDo)
 {
 	/*doc Object lexicalDo(expression)
 	Evaluates the message in the context of the receiver. 
-	The lexical context is added as a proto of the receiver while the argument is evaluated. 
+	The lexical context is added as a proto of the receiver while the argument is evaluated;
+	this makes locals from the calling context visible within the "lexicalDo" construct.
+	Same as "do".
 	Returns self.
 	*/
 
@@ -1835,6 +1842,26 @@ IO_METHOD(IoObject, lexicalDo)
 	return self;
 }
 
+IO_METHOD(IoObject, do)
+{
+	/*doc Object do(expression)
+	Evaluates the message in the context of the receiver.
+	The lexical context is added as a proto of the receiver while the argument is evaluated;
+	this makes locals from the calling context visible within the "do" construct.
+	Same as "lexicalDo".
+	Returns self.
+	*/
+
+	if (IoMessage_argCount(m) != 0)
+	{
+		IoMessage *argMessage = IoMessage_rawArgAt_(m, 0);
+		IoObject_rawAppendProto_(self, locals);
+		IoMessage_locals_performOn_(argMessage, self, self);
+		IoObject_rawRemoveProto_(self, locals);
+	}
+
+	return self;
+}
 IO_METHOD(IoObject, message)
 {
 	/*doc Object message(expression)

--- a/libs/iovm/source/IoObject.h
+++ b/libs/iovm/source/IoObject.h
@@ -187,6 +187,7 @@ IOVM_API IO_METHOD(IoObject, evalArgAndReturnSelf);
 IOVM_API IO_METHOD(IoObject, uniqueId);
 IOVM_API IO_METHOD(IoObject, do);
 IOVM_API IO_METHOD(IoObject, lexicalDo);
+IOVM_API IO_METHOD(IoObject, nonlexicalDo);
 IOVM_API IO_METHOD(IoObject, message);
 
 // compiler


### PR DESCRIPTION
This commit changes Object "do" to use the same implementation as "lexicalDo," so that slots in the calling context will be visible within the do block.  This removes a potential source of confusion for new users of Io.

The old implementation of "do" has been renamed "nonlexicalDo", in case it should be needed.

Additionally, the documentation comments for all three have been expanded to explain what the differences are.

Feel free to change the names or remove the other (non)lexicalDo methods if you think they will not be needed.
