### PR TITLE
Fix tutorial typo

### DIFF
--- a/docs/IoGuide.html
+++ b/docs/IoGuide.html
@@ -1869,14 +1869,14 @@ Getting the character (byte) at position N:
 Slicing:
 
 <pre>
-"Kirikuro" slice(0, 2)
+"Kirikuro" exSlice(0, 2)
 ==> "Ki"
 
-"Kirikuro" slice(-2)  # NOT: slice(-2, 0)!
+"Kirikuro" exSlice(-2)  # NOT: exSlice(-2, 0)!
 ==> "ro"
 
-Io> "Kirikuro" slice(0, -2)
-# "Kiriku"
+Io> "Kirikuro" exSlice(0, -2)
+==> "Kiriku"
 </pre>
 
 Stripping whitespace:

--- a/docs/IoTutorial.html
+++ b/docs/IoTutorial.html
@@ -212,10 +212,10 @@ Io> s findSeq("is")
 Io> s findSeq("test")
 ==> 10
 
-Io> s slice(10)
+Io> s exSlice(10)
 ==> "test"
 
-Io> s slice(2, 10)
+Io> s exSlice(2, 10)
 ==> "is is a "
 
 </PRE>


### PR DESCRIPTION
Very small IoTutorial.html and IoGuide.html fixes, including a fix for the now-deprecated slice method. (documenting exSlice instead.)
