### PR TITLE
Ensure 16-byte alignment for amd64 coroutine stack

### DIFF
--- a/libs/coroutine/source/Coro.c
+++ b/libs/coroutine/source/Coro.c
@@ -599,7 +599,7 @@ end:
 			if (64 > (- sav[i] + (uintptr_t)&i))
 				break;
 		assert(i < sz);
-		sav[i] = stackend - sizeof(uintptr_t) - 128;
+		sav[i] = stackend - sizeof(uintptr_t)*2 - 128;
 	}
 }
 


### PR DESCRIPTION
The AMD64 ABI requires that stacks be 16-byte aligned.  stackend is
going to be 16-byte aligned, 128 is a multiple of 16, and
sizeof(uintptr_t) is going to 8 on amd64, so this results in a stack
that is not 16-byte aligned on amd64 (at least for platforms where
this code branch is used, such as OpenBSD).  This results in bus errors
when floating point numbers are converted to strings, since snprintf
calls movaps with a non 16-byte aligned memory location.

With this patch, the iovm correctness tests pass on OpenBSD/amd64.
