### PR TITLE
Add a couple of method naming conventions to the programming guide

### DIFF
--- a/docs/IoCodingStandards.html
+++ b/docs/IoCodingStandards.html
@@ -9,22 +9,22 @@
 </head>
 <body>
 
-	<br>
+<br/>
 <center>
 <table cellpadding=0 cellspacing=0 border=0 style="width:65em; border-style:solid; border-width:0px; border-color:#000; padding-right:120px;">
 	<tr>
 		<td colspan=3>
 			<h1>Io&nbsp;Coding&nbsp;Standards</h1>
-			
+
 		</td>
 	</tr>
 	<tr>
 		<td></td><td></td><td>
-			
+
 <p>
-	<br>
-	<br>
-	<br>
+	<br/>
+	<br/>
+	<br/>
 
 <!--
 <table style="width:100%">
@@ -37,8 +37,8 @@
 </table>
 -->
 
-<br><br><br><br>
-
+<br/><br/><br/><br/>
+</p>
 </td>
 </tr>
 <tr>
@@ -48,7 +48,7 @@
 			<td>
 				&nbsp;&nbsp;&nbsp;&nbsp;
 			</td>
-			<td>
+      <td></td>
 
 </tr>
 
@@ -59,11 +59,10 @@
       <li>Prototypes should begin with a capital letter, e.g. <b>A</b>rray, <b>M</b>ap, <b>O</b>bject.</li>
       <li>Methods producing a (possibly modified) copy of an object should begin with "<b>as</b>", e.g. <b>as</b>Mutable, <b>as</b>Uppercase, <b>as</b>Number.</li>
     </ul>
-	</div>
-	<p><br><br><br>
+  <p><br/><br/><br/></p>
 	</td>
 	</tr>
-	
+
 
 
 
@@ -72,49 +71,47 @@
 	<tr><td align=right><a name="Comments"></a><h3>Comments</h3>
 	</td><td></td><td>
 		...
-	</div>
-	<p><br><br><br>
+  <p><br/><br/><br/></p>
 	</td>
 	</tr>
-	
-	
-	
+
+
+
 	<tr><td colspan=3 class=sectionDivider></td></tr>
 	<tr><td align=right><a name="Indentation"></a><h3>Indentation</h3>
 	</td><td></td><td>
 		...
-	</div>
-	<p><br><br><br>
+  <p><br/><br/><br/></p>
 	</td>
 	</tr>
-	
-	
-	
+
+
+
 	<tr><td colspan=3 class=sectionDivider></td></tr>
 	<tr><td align=right><a name="Whitespace"></a><h3>Whitespace</h3>
 	</td><td></td><td>
 		spaces and tabs, trailing spaces
-	</div>
-	<p><br><br><br>
+  <p><br/><br/><br/></p>
 	</td>
 	</tr>
-	
+
 
 	<tr><td colspan=3 class=sectionDivider></td></tr>
 	<tr><td align=right><a name="Commit Messages"></a><h3>Commit Messages</h3>
 	</td><td></td><td>
 		A short description of the change with a reference to the issue # if relevant.
-	</div>
-	<p><br><br><br>
+  <p><br/><br/><br/></p>
 	</td>
 	</tr>
-	
-		
+
+
 	</table>
-	
+
 </td>
 </tr>
 </table>
 
-<br><br><br>
-<br><br><br>
+<br/><br/><br/>
+<br/><br/><br/>
+</body>
+</html>


### PR DESCRIPTION
Fixes #233.

I also took the liberty of doing a minor whitespace and html tag cleanup in that file since there were a lot of unbalanced tags and unused divs (in a separate commit).
