### PR TITLE
Fix typos in core docs

### DIFF
--- a/docs/IoGuide.html
+++ b/docs/IoGuide.html
@@ -949,7 +949,7 @@ The above code creates a new "subclass" of object named Dog and adds a bark slot
 Dog bark
 </pre>
 
-The default return value of a block is the  result of the last expression.
+The default return value of a block is the result of the last expression.
 
 <h4>Arguments</h4>
 
@@ -1284,7 +1284,7 @@ Also supported are Smalltalk style ifTrue, ifFalse, ifNil and ifNonNil methods:
 (y < 10) ifTrue(x := y) ifFalse(x := 2)
 </pre>
 
-Notice that the condition expression must have parenthesis surrounding it.
+Notice that the condition expression must have parentheses surrounding it.
 
 
 
@@ -1676,7 +1676,7 @@ MyErrorType := Error clone
 Primitives are objects built into Io whose methods are typically implemented in C and store some hidden data in their instances. For example, the Number primitive has a double precision floating point number as its hidden data and its methods that do arithmetic operations are C functions. All Io primitives inherit from the Object prototype and are mutable. That is, their methods can be changed. The reference docs contain more info on primitives.
 <p>
 
-This document is not meant as a reference manual, but an overview of the base primitives and bindings is provided here to give the user a jump start and a feel for what is available and where to look in the reference documentation for further details.
+This document is not meant as a reference manual, but an overview of the base primitives and bindings is provided here to give the user a jump-start and a feel for what is available and where to look in the reference documentation for further details.
 
 
 </tr><tr><td colspan=3 class=sectionDivider></td></tr>
@@ -1908,7 +1908,7 @@ Splitting a string:
 ==> list("the", "quick", "brown", "fox")
 </pre>
 
-Splitting by others character is possible as well.
+Splitting by other characters is possible as well.
 
 <pre>
 "a few good men" split("e")
@@ -1944,7 +1944,7 @@ Interpolate will eval anything with #{} as Io code in the local context. The cod
 </td><td></td><td>
 	
 
-A range is a container containing a start and an end point, and instructions on how to get from the start, to the end. Using Ranges is often convenient when creating large lists of sequential data as they can be easily converted to lists, or as a replacement for the for() method.
+A range is a container containing a start and an end point, and instructions on how to get from the start to the end. Using Ranges is often convenient when creating large lists of sequential data as they can be easily converted to lists, or as a replacement for the for() method.
 
 <h4>The Range protocol</h4>
 

--- a/docs/reference/Core/Core/Block/index.html
+++ b/docs/reference/Core/Core/Block/index.html
@@ -112,7 +112,7 @@ print
 </b>
 <p>
 <div class=slotDescription>
-prints an Io source code representation of the block/method
+Prints an Io source code representation of the block/method.
 </div>
 <a name="Block-println"></a><b>
 println
@@ -149,7 +149,7 @@ setCode(aString)
 </b>
 <p>
 <div class=slotDescription>
-Set's the receiver's message to a compiled version of aString. Returns self
+Sets the receiver's message to a compiled version of aString. Returns self.
 </div>
 <a name="Block-setMessage"></a><b>
 setMessage(aMessage)

--- a/docs/reference/Core/Core/CFunction/index.html
+++ b/docs/reference/Core/Core/CFunction/index.html
@@ -73,7 +73,7 @@ name
 </b>
 <p>
 <div class=slotDescription>
-Returns the CFunction name in the form CFunction_Pointer.")
+Returns the CFunction name in the form CFunction_Pointer.
 </div>
 <a name="CFunction-performOn"></a><b>
 performOn(target, blockLocals, optionalMessage, optionalContext)

--- a/docs/reference/Core/Core/Coroutine/index.html
+++ b/docs/reference/Core/Core/Coroutine/index.html
@@ -138,7 +138,7 @@ parentCoroutine
 </b>
 <p>
 <div class=slotDescription>
-Returns the parent coroutine this one was chained from or nil if it wasn't chained. When a Coroutine ends, it will attempt to resume it's parent.
+Returns the parent coroutine this one was chained from or nil if it wasn't chained. When a Coroutine ends, it will attempt to resume its parent.
 </div>
 <a name="Coroutine-pause"></a><b>
 pause

--- a/docs/reference/Core/Core/File/index.html
+++ b/docs/reference/Core/Core/File/index.html
@@ -285,7 +285,7 @@ moveTo(pathString)
 <p>
 <div class=slotDescription>
 Moves the file specified by the receiver's path to the
-	new path pathString. Raises an File doesNotExist exception if the
+	new path pathString. Raises a File doesNotExist exception if the
 	file does not exist or a File nameConflict exception if the file
 	nameString already exists.
 </div>
@@ -435,7 +435,7 @@ reopen(otherFile, mode)
 </b>
 <p>
 <div class=slotDescription>
-Reopen's otherFile and redirects its stream to this file's path using mode.
+Reopens otherFile and redirects its stream to this file's path using mode.
 	If mode is omitted, it is copied from otherFile.
 	Returns self or raises a File exception on error.
 </div>
@@ -579,7 +579,7 @@ truncateToSize(numberOfBytes)
 </b>
 <p>
 <div class=slotDescription>
-Trunctates the file's size to the numberOfBytes. Returns self.
+Truncates the file's size to the numberOfBytes. Returns self.
 </div>
 <a name="File-userId"></a><b>
 userId

--- a/docs/reference/Core/Core/List/index.html
+++ b/docs/reference/Core/Core/List/index.html
@@ -54,7 +54,7 @@ appendIfAbsent(anObject)
 </b>
 <p>
 <div class=slotDescription>
-Adds each value not already contained by the receiver, returns self.
+Adds each value not already contained by the receiver. Returns self.
 </div>
 <a name="List-appendSeq"></a><b>
 appendSeq(aList1, aList2, ...)

--- a/docs/reference/Core/Core/Map/index.html
+++ b/docs/reference/Core/Core/Map/index.html
@@ -141,14 +141,14 @@ isEmpty
 </b>
 <p>
 <div class=slotDescription>
-returns true if this map doesn't contain any pairs.
+Returns true if this map doesn't contain any pairs.
 </div>
 <a name="Map-isNotEmpty"></a><b>
 isNotEmpty
 </b>
 <p>
 <div class=slotDescription>
-returns true if this map contains at least one pair.
+Returns true if this map contains at least one pair.
 </div>
 <a name="Map-justSerialized"></a><b>
 justSerialized(stream)
@@ -198,14 +198,14 @@ reverseMap
 </b>
 <p>
 <div class=slotDescription>
-Create a new Map using values as keys and keys as values
+Creates a new Map using values as keys and keys as values
 </div>
 <a name="Map-select"></a><b>
 select(optionalIndex, optionalValue, message)
 </b>
 <p>
 <div class=slotDescription>
-Create a new Map with keys,values of self for which message evaluated
+Creates a new Map with keys,values of self for which message evaluated
 		to non-nil.
 </div>
 <a name="Map-size"></a><b>

--- a/docs/reference/Core/Core/Message/index.html
+++ b/docs/reference/Core/Core/Message/index.html
@@ -59,7 +59,7 @@ appendArg(aMessage)
 </b>
 <p>
 <div class=slotDescription>
-Adds aMessage to the argument list of receiver. Examples,
+Adds aMessage to the argument list of receiver. Examples:
 <pre>	
 Io> message(a) appendArg(message(b))
 ==> a(b)
@@ -154,8 +154,8 @@ characterNumber
 </b>
 <p>
 <div class=slotDescription>
-Returns the message character number. The charcter number is typically
-	the beginning character index in the source text from with the message was read.
+Returns the message character number. The character number is typically
+	the beginning character index in the source text from which the message was read.
 </div>
 <a name="Message-clone"></a><b>
 clone
@@ -263,8 +263,8 @@ lineNumber
 </b>
 <p>
 <div class=slotDescription>
-Returns the line number of the message. The charcter number
-	is typically the line number in the source text from with the message was read.
+Returns the line number of the message. The character number
+	is typically the line number in the source text from which the message was read.
 </div>
 <a name="Message-name"></a><b>
 name

--- a/docs/reference/Core/Core/Object/index.html
+++ b/docs/reference/Core/Core/Object/index.html
@@ -24,7 +24,7 @@
 <td align=right></td>
 <td></td>
 <td>An Object is a key/value dictionary with string keys and values of any type.
-The prototype Object contains a clone slot that is a CFuntion that creates new objects.
+The prototype Object contains a clone slot that is a CFunction that creates new objects.
 When cloned, an Object will call its init slot (with no arguments).
 </td></tr>
 <tr><td colspan=3>&nbsp;</td></tr>
@@ -265,7 +265,7 @@ checkMemory()
 </b>
 <p>
 <div class=slotDescription>
-accesses memory in the IoObjectData struct that should be accessible.  Should cause a memory access
+Accesses memory in the IoObjectData struct that should be accessible.  Should cause a memory access
 	exception if memory is corrupt.
 </div>
 <a name="Object-clone"></a><b>

--- a/docs/reference/Core/Core/Sequence/index.html
+++ b/docs/reference/Core/Core/Sequence/index.html
@@ -63,7 +63,7 @@ Multiplies the values of aSeq to the corresponding values of the receiver.
 </b>
 <p>
 <div class=slotDescription>
-Vector addition - Adds the values of aSeq to the corresponding values of the receiver 
+Vector addition - adds the values of aSeq to the corresponding values of the receiver 
 	returning a new vector with the result.
 	Only works on Sequences whose item type is numeric.
 </div>
@@ -134,7 +134,7 @@ acos
 </b>
 <p>
 <div class=slotDescription>
-Sets each value of the Sequence to the trigonometric arcsine of it's value.
+Sets each value of the Sequence to the trigonometric arcsine of its value.
 Returns self.
 </div>
 <a name="Sequence-afterSeq"></a><b>
@@ -595,7 +595,7 @@ clipAfterSeq(aSequence)
 <p>
 <div class=slotDescription>
 Removes the contents of the receiver after the end of
-	the first occurance of aSequence. Returns true if anything was
+	the first occurrence of aSequence. Returns true if anything was
 	removed, or false otherwise.
 </div>
 <a name="Sequence-clipAfterStartOfSeq"></a><b>
@@ -604,7 +604,7 @@ clipAfterStartOfSeq(aSequence)
 <p>
 <div class=slotDescription>
 Removes the contents of the receiver after the beginning of
-	the first occurance of aSequence. Returns true if anything was
+	the first occurrence of aSequence. Returns true if anything was
 	removed, or false otherwise.
 </div>
 <a name="Sequence-clipBeforeEndOfSeq"></a><b>
@@ -613,7 +613,7 @@ clipBeforeEndOfSeq(aSequence)
 <p>
 <div class=slotDescription>
 Removes the contents of the receiver before the end of
-	the first occurance of aSequence. Returns true if anything was
+	the first occurrence of aSequence. Returns true if anything was
 	removed, or false otherwise.
 </div>
 <a name="Sequence-clipBeforeSeq"></a><b>
@@ -1258,7 +1258,7 @@ removeSeq(aSequence)
 </b>
 <p>
 <div class=slotDescription>
-Removes occurances of aSequence from the receiver.
+Removes occurrences of aSequence from the receiver.
 </div>
 <a name="Sequence-removeSlice"></a><b>
 removeSlice(startIndex, endIndex)
@@ -1287,7 +1287,7 @@ replaceFirstSeq(aSequence, anotherSequence, optionalStartIndex)
 </b>
 <p>
 <div class=slotDescription>
-Returns a new Sequence with the first occurance of aSequence
+Returns a new Sequence with the first occurrence of aSequence
 	replaced with anotherSequence in the receiver. If optionalStartIndex is
 	provided, the search for aSequence begins at that index. Returns self.
 </div>
@@ -1303,7 +1303,7 @@ replaceSeq(aSequence, anotherSequence)
 </b>
 <p>
 <div class=slotDescription>
-Returns a new Sequence with all occurances of aSequence
+Returns a new Sequence with all occurrences of aSequence
 	replaced with anotherSequence in the receiver. Returns self.
 </div>
 <a name="Sequence-reverse"></a><b>
@@ -1414,7 +1414,7 @@ size
 <p>
 <div class=slotDescription>
 Returns the length in number of items (which may or may not
-be the number of bytes, depending on the item type) of the receiver. For example,
+be the number of bytes, depending on the item type) of the receiver. For example:
 <p>
 <pre>	
 "abc" size == 3
@@ -1547,7 +1547,7 @@ tan
 </b>
 <p>
 <div class=slotDescription>
-Sets each value of the Sequence to the trigonometric tangent of it's value.
+Sets each value of the Sequence to the trigonometric tangent of its value.
 Returns self.
 </div>
 <a name="Sequence-tanh"></a><b>
@@ -1615,7 +1615,7 @@ with(aSequence, ...)
 </b>
 <p>
 <div class=slotDescription>
-Returns a new Sequence which is the concatination of the arguments.
+Returns a new Sequence which is the concatenation of the arguments.
 	The returned sequence will have the same mutability status as the receiver.
 </div>
 <a name="Sequence-withStruct"></a><b>

--- a/docs/reference/Core/Core/System/index.html
+++ b/docs/reference/Core/Core/System/index.html
@@ -47,7 +47,7 @@ args
 </b>
 <p>
 <div class=slotDescription>
-Returns the list of command line argument strings the program was run with.")
+Returns the list of command line argument strings the program was run with.
 </div>
 <a name="System-daemon"></a><b>
 daemon(dontChroot, dontRedirectOutputStreams)


### PR DESCRIPTION
Just some typo fixes, is all - I've been in a copyediting sort of mood today.
