### PR TITLE
Fix recursive inline on OS X

### DIFF
--- a/libs/basekit/source/Common_inline.h
+++ b/libs/basekit/source/Common_inline.h
@@ -53,7 +53,7 @@ Kudos to Daniel A. Koepke
 #if defined(__APPLE__) 
 
 	#ifndef NS_INLINE
-		#define NS_INLINE static __inline__ __attribute__((always_inline))
+		#define NS_INLINE static inline
 	#endif
 
 	#ifdef IO_IN_C_FILE


### PR DESCRIPTION
This patch was originally proposed in #135. Make fails on some platforms/compilers with a "recursive inlining" error.

In Homebrew we've been applying this patch for two years now unconditionally, on all OS versions and compilers, without problems.
