### PR TITLE
message evaluation fix

### DIFF
--- a/libs/iovm/source/IoMessage.c
+++ b/libs/iovm/source/IoMessage.c
@@ -1313,15 +1313,12 @@ IoMessage *IoMessage_asMessageWithEvaluatedArgs(IoMessage *self, IoObject *local
 		context = IoMessage_locals_valueArgAt_(m, locals, 0);
 	}
 
-	if (IoMessage_needsEvaluation(self))
+	if (!IoMessage_needsEvaluation(self))
 	{
-		sendMessage = IoMessage_newWithName_(state, IoMessage_name(self));
-	}
-	else
-	{
-		sendMessage = self;
+		return self;
 	}
 
+	sendMessage = IoMessage_newWithName_(state, IoMessage_name(self));
 	for (i = 0; i < max; i ++)
 	{
 		IoMessage *arg = IoMessage_rawArgAt_(self, i);


### PR DESCRIPTION
trying to hunt down the bug I was experiencing in the following issue: https://github.com/stevedekorte/io/issues/244 and this seems to be the fix.

I don't really know the codebase so this possibly breaks stuff that I'm unaware of but the tests still pass and it fixes the cases shown in the issue. eg:

```
Io> List clone @append(2 * 10)
==> list(20)
```
