### PR TITLE
preserve the leading / in a url resource

### DIFF
--- a/addons/HttpClient/io/HCUrl.io
+++ b/addons/HttpClient/io/HCUrl.io
@@ -43,8 +43,8 @@ HCUrl := Object clone do(
 	
 	resource := method(
 		r := urlSeq afterSeq("//") ?afterSeq("/")
-		if(r == nil or r == "", r = "/")
-		r beforeSeq("#")
+		if(r == nil, r = "")
+		"/"..(r) beforeSeq("#")
 	)
 	
 	get := method(


### PR DESCRIPTION
HCUrl with("http://server/resource") was generating "GET resource" when "GET /resource" is correct. This patch preserves the leading / on the resource response for the HCUrl object.
