### PR TITLE
Changed type to get libmemcached >= 1.0.17 to compile. Still gives warning ...

### DIFF
--- a/addons/Memcached/source/IoMemcached.c
+++ b/addons/Memcached/source/IoMemcached.c
@@ -476,7 +476,7 @@ IoObject *IoMemcached_stats(IoMemcached *self, IoObject *locals, IoMessage *m)
 	int errors = 0;
 	uint32_t pos = 0;
 	while(pos < memcached_server_count(DATA(self)->mc)) {
-		memcached_server_instance_st server = memcached_server_instance_by_position(DATA(self)->mc, pos);
+		const memcached_instance_st *server = memcached_server_instance_by_position(DATA(self)->mc, pos);
 		if(server == NULL)
 			continue;
 


### PR DESCRIPTION
Potential fix for stevedekorte/io#247 and Homebrew/homebrew#25315.

I think some cpp stuff needs to be done here to account for older and younger versions of libmemcached, but I'm not sure how that all works.

Still gives warning for:
io/addons/Memcached/source/IoMemcached.c:46:2: warning: implicit declaration of function IoState_registerProtoWithFunc_ is invalid in C99