### PR TITLE
Fix addon loading issue

### DIFF
--- a/libs/iovm/io/AddonLoader.io
+++ b/libs/iovm/io/AddonLoader.io
@@ -52,7 +52,11 @@ Addon := Object clone do(
 		dependencies foreach(d,
 			if(Lobby getSlot(d) == nil,
 				//writeln("loading dependency ", d)
-				AddonLoader loadAddonNamed(d)
+				if(AddonLoader hasAddonNamed(d),
+				    AddonLoader loadAddonNamed(d)
+				) else(
+				    Exception raise("Failed to load Addon " .. name .. " - Addon " .. name .. " depends on Addon " .. d .. " but Addon " .. d .. " cannot be found.")
+				)
 			)
 		)
 	)


### PR DESCRIPTION
Check if dependency exists before loading it when loading the dependencies for an addon and raise an exception if it doesn't. This fixes #270.
