### PR TITLE
Fix inline functions for GCC on Mac OS X

### DIFF
--- a/libs/basekit/source/Common_inline.h
+++ b/libs/basekit/source/Common_inline.h
@@ -26,6 +26,7 @@ Kudos to Daniel A. Koepke
 
 #undef IO_DECLARE_INLINES
 #undef IOINLINE
+#undef IOINLINE_RECURSIVE
 
 /*
 #if defined(__cplusplus)
@@ -53,18 +54,21 @@ Kudos to Daniel A. Koepke
 #if defined(__APPLE__) 
 
 	#ifndef NS_INLINE
-		#define NS_INLINE static inline
+		#define NS_INLINE static __inline__ __attribute__((always_inline))
 	#endif
 
-	#ifdef IO_IN_C_FILE
-		// in .c 
-		#define IO_DECLARE_INLINES
-		#define IOINLINE NS_INLINE
+	#define IO_DECLARE_INLINES
+	#define IOINLINE NS_INLINE
+
+	/* clang is smart enough to handle inlining recursive functions,
+	 * so defer to the value defined by NS_INLINE; GCC is not, so
+	 * fall back to static inline for it.
+	 */
+	#ifdef __clang__
+		#define IOINLINE_RECURSIVE NS_INLINE
 	#else
-		// in .h 
-		#define IO_DECLARE_INLINES
-		#define IOINLINE NS_INLINE
-	#endif 	
+		#define IOINLINE_RECURSIVE static inline
+	#endif
 
 /*		
 	#include "TargetConditionals.h"
@@ -104,10 +108,12 @@ Kudos to Daniel A. Koepke
 		// in .c 
 		#define IO_DECLARE_INLINES
 		#define IOINLINE inline
+		#define IOINLINE_RECURSIVE inline
 	#else
 		// in .h 
 		#define IO_DECLARE_INLINES
 		#define IOINLINE static inline
+		#define IOINLINE_RECURSIVE static inline
 	#endif 
 	
 #elif defined(__linux__) || defined(__OpenBSD__) || defined(__NetBSD__) || defined(__FreeBSD__)
@@ -116,10 +122,12 @@ Kudos to Daniel A. Koepke
 		// in .c 
 		#define IO_DECLARE_INLINES
 		#define IOINLINE inline
+		#define IOINLINE_RECURSIVE inline
 	#else
 		// in .h 
 		#define IO_DECLARE_INLINES
 		#define IOINLINE extern inline
+		#define IOINLINE_RECURSIVE extern inline
 	#endif 
 	
 #else
@@ -128,10 +136,12 @@ Kudos to Daniel A. Koepke
 		// in .c 
 		#define IO_DECLARE_INLINES
 		#define IOINLINE 
+		#define IOINLINE_RECURSIVE
 	#else
 		// in .h 
 		#define IO_DECLARE_INLINES
 		#define IOINLINE inline
+		#define IOINLINE_RECURSIVE inline
 	#endif 
 	
 #endif

--- a/libs/iovm/source/IoObject_inline.h
+++ b/libs/iovm/source/IoObject_inline.h
@@ -275,7 +275,7 @@ IOINLINE void IoObject_inlineSetSlot_to_(IoObject *self,
 	*/
 }
 
-IOINLINE IoObject *IoObject_rawGetSlot_context_(IoObject *self,
+IOINLINE_RECURSIVE IoObject *IoObject_rawGetSlot_context_(IoObject *self,
 												IoSymbol *slotName,
 												IoObject **context)
 {
@@ -318,7 +318,7 @@ IOINLINE IoObject *IoObject_rawGetSlot_context_(IoObject *self,
 	return v;
 }
 
-IOINLINE IoObject *IoObject_rawGetSlot_(IoObject *self, IoSymbol *slotName)
+IOINLINE_RECURSIVE IoObject *IoObject_rawGetSlot_(IoObject *self, IoSymbol *slotName)
 {
 	register IoObject *v = (IoObject *)NULL;
 


### PR DESCRIPTION
IOObject has two inline functions which call themselves recursively. GCC doesn't seem to be able to deal with this, while clang is.

The `IOINLINE` macro is defined as `static inline` on OS X if `NS_INLINE` is not defined; otherwise the predefined value of `NS_INLINE` is used. `NS_INLINE` is only defined in ObjC code (e.g., the ObjC bridge), so in practice a different definition of `IOINLINE` is used there from everywhere else. The default definition of `NS_INLINE` uses the `always_inline` keyword. This leads to build errors on GCC (but not clang): GCC is directed to always inline the inline functions, but it can't inline the recursive functions and hence errors out.

This patch introduces a new `IOINLINE_RECURSIVE` macro to cover the recursive functions; it uses `always_inline` where possible (e.g. clang) and falls back to `static inline` otherwise. Since this is separate from the `IOINLINE` macro, it makes it possible to use `always_inline` for the other inline functions whereas it wasn't before.

This has been tested using clang, GCC 4.2 and GCC 4.8 on Mac OS X 10.9.2 and GCC 4.2 on Mac OS X 10.6.8; it builds on all of them.

Fixes #260.
