### PR TITLE
Fixed href to try, catch section

### DIFF
--- a/docs/IoGuide.html
+++ b/docs/IoGuide.html
@@ -84,7 +84,7 @@
 
 <div class=indexSection><a href="#Exceptions">Exceptions</a></div>
 <div class=indexItem><a href="#Exceptions-Raise">Raise</a></div>
-<div class=indexItem><a href="#ExceptionsTry-and-Catch">try, catch</a></div>
+<div class=indexItem><a href="#Exceptions-Try-and-Catch">try, catch</a></div>
 <div class=indexItem><a href="#Exceptions-Pass">Pass</a></div>
 <div class=indexItem><a href="#Exceptions-Custom-Exceptions">Custom Exceptions</a></div>
 


### PR DESCRIPTION
A dash was missing in href of the link to the try, catch section.