### PR TITLE
Permitting non-Apple builds by not requiring IOKit

### DIFF
--- a/addons/AppleSensors/CMakeLists.txt
+++ b/addons/AppleSensors/CMakeLists.txt
@@ -24,16 +24,15 @@ set(SRCS
 )
 
 find_library(IOKIT IOKit)
-if (NOT IOKIT)
-    message(FATAL_ERROR "IOKit not found")
+if (IOKIT)
+  #add_executable(IoAppleSensors ${program_SOURCES})
+
+  # Now build the shared library
+  add_library(IoAppleSensors SHARED ${SRCS})
+  add_dependencies(IoAppleSensors iovmall)
+  target_link_libraries(IoAppleSensors iovmall ${IOKIT})
+
+  # Install the addon to our global addons hierarchy.
+  install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR} DESTINATION lib/io/addons)
+  install(DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/_build DESTINATION lib/io/addons/AppleSensors)
 endif()
-#add_executable(IoAppleSensors ${program_SOURCES})
-
-# Now build the shared library
-add_library(IoAppleSensors SHARED ${SRCS})
-add_dependencies(IoAppleSensors iovmall)
-target_link_libraries(IoAppleSensors iovmall ${IOKIT})
-
-# Install the addon to our global addons hierarchy.
-install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR} DESTINATION lib/io/addons)
-install(DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/_build DESTINATION lib/io/addons/AppleSensors)


### PR DESCRIPTION
Linux builds fail because the AppleSensors addon is requiring that IOKit is present:

{code}
% ./build.sh 
-- Configuration set to: DebugFast
CMake Error at addons/AppleSensors/CMakeLists.txt:28 (message):
  IOKit not found


-- Configuring incomplete, errors occurred!
See also "/home/presto/software/io/build/CMakeFiles/CMakeOutput.log".
See also "/home/presto/software/io/build/CMakeFiles/CMakeError.log".
-- Configuration set to: DebugFast
CMake Error at addons/AppleSensors/CMakeLists.txt:28 (message):
  IOKit not found


-- Configuring incomplete, errors occurred!
See also "/home/presto/software/io/build/CMakeFiles/CMakeOutput.log".
See also "/home/presto/software/io/build/CMakeFiles/CMakeError.log".
make: *** [cmake_check_build_system] Error 1
{code}

It appears that just making the definition of that module conditional on the presence of IOKit would allow builds to succeed on non-Apple operating systems.  If any other variations are desired (somehow checking the OS directly, and then requiring IOKit if on MacOS?), that could be a good modification.