### PR TITLE
Fix an infinite loop in 'Sequence pack'.

### DIFF
--- a/libs/iovm/source/IoSeq_immutable.c
+++ b/libs/iovm/source/IoSeq_immutable.c
@@ -1748,7 +1748,7 @@ IO_METHOD(IoSeq, pack)
 					else
 						size = count;
 					doBigEndian = 0;
-					count = 0; //finish processing
+					count = 1; //finish processing
 				break;
 			}
 			


### PR DESCRIPTION
When given two or more consecutive strings to pack, 'pack' would enter an
infinite loop. When given nonconsecutive strings, 'pack' would throw
an exception stating it expected the next argument to be a 'Sequence'.