### PR TITLE
Fix a segfault in 'Sequence unpack'.

### DIFF
--- a/libs/iovm/source/IoSeq_immutable.c
+++ b/libs/iovm/source/IoSeq_immutable.c
@@ -1909,7 +1909,7 @@ IO_METHOD(IoSeq, unpack)
 						memcpy(uap, &selfUArray[seqPos], count);
 					}
 					seqPos += count;
-					count = 0;
+					count = 1;
 					v = IoSeq_newWithUArray_copy_(IOSTATE, ua, 0);
 					break;
 				}


### PR DESCRIPTION
When told to unpack a string, 'unpack' would cause Io to segfault.