### PR TITLE
Possible fix for tmpnam.

### DIFF
--- a/addons/Socket/source/LocalNameServers.c
+++ b/addons/Socket/source/LocalNameServers.c
@@ -157,7 +157,8 @@ void LocalNameServers_findIps(LocalNameServers *self)
 
 void LocalNameServers_findIps(LocalNameServers *self)
 {
-	char *path = tmpnam(NULL);
+        char *path = NULL;
+	mkstemp(path);
 	char *command = io_malloc(1024);
 	char *answerBuffer = io_calloc(1, 1024);
 	char *answer = answerBuffer;


### PR DESCRIPTION
[According to here](http://www.gnu.org/software/libc/manual/html_node/Temporary-Files.html) you should not use `tmpnam`. I am not familiar with Socket programming, so I am not sure how to test. I believe I have fixed it by replacing it with `mkstemp`, but I'm not completely sure. Nevertheless, this is an issue that should be addressed.
