### PR TITLE
Bugfix: interactive interpreter exits abnormally

### DIFF
--- a/libs/iovm/io/A4_Exception.io
+++ b/libs/iovm/io/A4_Exception.io
@@ -172,7 +172,7 @@ Coroutine do(
 			if(next,
 				next resume
 			,
-				//Exception raise("Scheduler: nothing left to resume so we are exiting")
+				Exception raise("Scheduler: nothing left to resume so we are exiting")
 				writeln("Scheduler: nothing left to resume so we are exiting")
 				self showStack
 				System exit


### PR DESCRIPTION
Bugfix: interactive interpreter prompts "Scheduler: nothing left to resume so we are exiting" and exits
