### PR TITLE
CMake fixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,6 +23,12 @@
 # hierarchy.
 cmake_minimum_required(VERSION 2.8)
 
+# Mac OS X: Setting policy CMP0042 to the new behavior generates dylibs with
+# RPATH-relative install name that is better suited for Mac OS X applications
+# embedding Io in their bundle.
+if(POLICY CMP0042)
+	cmake_policy(SET CMP0042 NEW)
+endif()
 	
 # Project name, this gets prefixed to a bunch of stuff under the hood. No
 # spaces, or anything silly like that please.

--- a/libs/CMakeLists.txt
+++ b/libs/CMakeLists.txt
@@ -90,7 +90,7 @@ list(APPEND IOVMALL_STATIC_SRCS ${CMAKE_CURRENT_SOURCE_DIR}/iovm/source/IoVMInit
 # ...And the static library. Refer to IOVMALL_STATIC_SRCS definition
 # up top.
 add_library(iovmall_static STATIC ${IOVMALL_STATIC_SRCS})
-add_dependencies(iovmall_static io2c basekit coroutine garabagecollector iovmall)
+add_dependencies(iovmall_static io2c basekit coroutine garbagecollector iovmall)
 
 # Define the subdirectories we can reach from here that we want
 # to go into and build stuff.


### PR DESCRIPTION
 - On Mac OS X, generating dylibs with an "@rpath"-relative install name makes life easier for people who like to embed Io within their app
 - Fixed a typo