### PR TITLE
power-ucontext: don't typedef ulong twice

### DIFF
--- a/libs/coroutine/source/power-ucontext.h
+++ b/libs/coroutine/source/power-ucontext.h
@@ -2,7 +2,6 @@ typedef unsigned long ulong;
 
 #define	setcontext(u)	_setmcontext(&(u)->mc)
 #define	getcontext(u)	_getmcontext(&(u)->mc)
-typedef unsigned long ulong; /* not available on OS X 10.4.11 */
 typedef struct mcontext mcontext_t;
 typedef struct ucontext ucontext_t;
 struct mcontext


### PR DESCRIPTION
b4719106b8ed90757e1ef4b85d4176f2102b4f9e added a second typedef for this type, which already existed at line 5 as of 6067211546c75e924d0d30129aa6a1502eba86ef.

refs mistydemeo/tigerbrew#81.