### PR TITLE
Fix for inlining in C11 mode

### DIFF
--- a/libs/basekit/source/Common_inline.h
+++ b/libs/basekit/source/Common_inline.h
@@ -117,19 +117,31 @@ Kudos to Daniel A. Koepke
 	#endif 
 	
 #elif defined(__linux__) || defined(__OpenBSD__) || defined(__NetBSD__) || defined(__FreeBSD__)
-
-	#ifdef IO_IN_C_FILE
-		// in .c 
-		#define IO_DECLARE_INLINES
-		#define IOINLINE inline
-		#define IOINLINE_RECURSIVE inline
+	#ifdef __GNUC_STDC_INLINE__
+		#ifdef IO_IN_C_FILE
+			// in .c
+			#define IO_DECLARE_INLINES
+			#define IOINLINE
+			#define IOINLINE_RECURSIVE
+		#else
+			// in .h
+			#define IO_DECLARE_INLINES
+			#define IOINLINE inline
+			#define IOINLINE_RECURSIVE inline
+		#endif
 	#else
-		// in .h 
-		#define IO_DECLARE_INLINES
-		#define IOINLINE extern inline
-		#define IOINLINE_RECURSIVE extern inline
-	#endif 
-	
+		#ifdef IO_IN_C_FILE
+			// in .c
+			#define IO_DECLARE_INLINES
+			#define IOINLINE inline
+			#define IOINLINE_RECURSIVE inline
+		#else
+			// in .h
+			#define IO_DECLARE_INLINES
+			#define IOINLINE extern inline
+			#define IOINLINE_RECURSIVE extern inline
+		#endif
+	#endif
 #else
 
 	#ifdef IO_IN_C_FILE


### PR DESCRIPTION
This is intended to fix #316. I tested that it builds on Fedora 23 64-bit and also on Lubuntu 15.10 32-bit where it fails elsewhere in `UArray_math.c` (the master branch is also affected.) I will try and fix that too. However this patch needs to be tested on the BSDs, and also on Linux with a GCC 4.x compiler which has the 'old' inline behaviour. I don't have access to any of those systems here. Hope this helps.