### PR TITLE
Fix round-trip of 'list asEncodedList asDecodedList.'

### DIFF
--- a/libs/iovm/tests/correctness/ListTest.io
+++ b/libs/iovm/tests/correctness/ListTest.io
@@ -488,6 +488,8 @@ ListTest := UnitTest clone do(
 		assertEquals(t, t asEncodedList asDecodedList)
 		t := list("foo")
 		assertEquals(t, t asEncodedList asDecodedList)
+		t := list("foo", nil)
+		assertEquals(t, t asEncodedList asDecodedList)
 	)
 
     testSlice := method(


### PR DESCRIPTION
Previously failed if the list ended in 'nil.' (reported in #306)

This was because the code always checked there were 7 bytes remaining in
the encoded data before decoding the next value, whereas 'nil' only
requires three bytes (all other types do require at least 7.)

A test has been added to ListTest.io.