### PR TITLE
Stop `List asSimpleString` from recursing indefinitely

### DIFF
--- a/libs/iovm/io/A3_List.io
+++ b/libs/iovm/io/A3_List.io
@@ -275,7 +275,7 @@ Io> list("a", "b", "cd") groupBy(i, v, i == 1) asJson
 
     asString := method("list(" .. self join(", ") .. ")")
     asSimpleString := method(
-        result := self slice(0, 30) asString
+        result := self slice(0, 30) map(asSimpleString) asString
         if(result size > 40,
             result exSlice(0, 37) .. "..."
         ,


### PR DESCRIPTION
Stop `List asSimpleString` from recursing indefinitely when called on lists that (directly or indirectly) contain themselves.

This represents the list using the simple strings of its contents,
rather than the full strings, so the output of `List asSimpleString`
may be different.

Proposed fix for #301 