### PR TITLE
Fix off-by-one error

### DIFF
--- a/libs/basekit/source/cdecode.c
+++ b/libs/basekit/source/cdecode.c
@@ -12,7 +12,7 @@ int base64_decode_value(char value_in)
 	static const char decoding[] = {62,-1,-1,-1,63,52,53,54,55,56,57,58,59,60,61,-1,-1,-1,-2,-1,-1,-1,0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,-1,-1,-1,-1,-1,-1,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51};
 	static const char decoding_size = sizeof(decoding);
 	value_in -= 43;
-	if (value_in < 0 || value_in > decoding_size) return -1;
+	if (value_in < 0 || value_in >= decoding_size) return -1;
 	return decoding[(int)value_in];
 }
 


### PR DESCRIPTION
There's an off-by-one error in base64_decode_value that results in undefined behaviour when it's passed `'\x7b'`