### PR TITLE
Fix build warnings

### DIFF
--- a/libs/basekit/source/PortableStrlcpy.h
+++ b/libs/basekit/source/PortableStrlcpy.h
@@ -4,6 +4,4 @@
 #include <sys/types.h> // size_t
 #endif
 
-#define strlcpy(d, s, l) PortableStrlcpy((d), (s), (l))
-
 size_t PortableStrlcpy(char*, const char*, size_t);

--- a/libs/basekit/source/UArray_math.h
+++ b/libs/basekit/source/UArray_math.h
@@ -67,7 +67,7 @@ BASEKIT_API void UArray_tanh(UArray *self);
 BASEKIT_API void UArray_exp(UArray *self);
 BASEKIT_API void UArray_log(UArray *self);
 BASEKIT_API void UArray_log10(UArray *self);
-BASEKIT_API void UArray_pow(UArray *self, const UArray *other);
+BASEKIT_API void UArray_power_(UArray *self, const UArray *other);
 
 BASEKIT_API void UArray_sqrt(UArray *self);
 BASEKIT_API void UArray_ceil(UArray *self);


### PR DESCRIPTION
Two minor fixes:

* Remove unused strlcpy() macro.
* Fix undeclared symbol warning.