### PR TITLE
Make INSTALL_PREFIX overridable in build.sh.

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 # Build script for Steve
 
-INSTALL_PREFIX="/usr/local"
+INSTALL_PREFIX="${INSTALL_PREFIX:-/usr/local}"
 
 if [ X"$1" = X"linkInstall" ]; then
 	rm -rf $INSTALL_PREFIX/lib/io $INSTALL_PREFIX/bin/io


### PR DESCRIPTION
Use $INSTALL_PREFIX if set in the environment instead of /usr/local.
Usage:

    env INSTALL_PREFIX=$HOME/opt/io build.sh install