### PR TITLE
update documentation

### DIFF
--- a/docs/IoGuide.html
+++ b/docs/IoGuide.html
@@ -1922,7 +1922,7 @@ Converting to number:
 ==> 13
 
 "a13" asNumber
-==> nil
+==> nan
 </pre>
 
 String interpolation:


### PR DESCRIPTION
It appears that `nan` is the return value for the `asNumber` method when a non-numeric string is passed. This PR simply updates the Io Guide to reflect this.