### PR TITLE
Bugfix: fix fibonacci example: return 1 for 2

### DIFF
--- a/samples/shootout/recursive.io
+++ b/samples/shootout/recursive.io
@@ -34,7 +34,7 @@ ack := method(x, y,
 /* ----------- */
 
 fib := method(n,
-  if(n < 2, return 1)
+  if(n <= 2, return 1)
   return fib(n - 1) + fib(n - 2)
 )
 


### PR DESCRIPTION
Bugfix: fix fibonacci example: 

According to Fibonacci F(2) = 1.