### PR TITLE
Regex: don't print "Registering Regex..."; OpenGL: don't add IoBoxInit.c to sources

### DIFF
--- a/addons/OpenGL/CMakeLists.txt
+++ b/addons/OpenGL/CMakeLists.txt
@@ -42,7 +42,7 @@ if(OPENGL_FOUND AND OPENGL_GLU_FOUND AND GLUT_FOUND AND ((GLUT_Xmu_LIBRARY AND G
 		"${CMAKE_CURRENT_SOURCE_DIR}/source/IoOpenGLInit.c"
     # building with box sources prevents linkining issue
     "${CMAKE_CURRENT_SOURCE_DIR}/../Box/source/IoBox.c"
-    "${CMAKE_CURRENT_SOURCE_DIR}/../Box/source/IoBoxInit.c"
+    # "${CMAKE_CURRENT_SOURCE_DIR}/../Box/source/IoBoxInit.c"
 	)
 
 	# Now build the shared library

--- a/addons/Regex/source/IoRegex.c
+++ b/addons/Regex/source/IoRegex.c
@@ -37,7 +37,7 @@ IoRegex *IoRegex_proto(void *state)
 
 	IoObject_setDataPointer_(self, calloc(1, sizeof(IoRegexData)));
 	DATA(self)->pattern = IOSYMBOL("");
-	printf("Registering Regex: %s\n", protoId);
+	// printf("Registering Regex: %s\n", protoId);
 	IoState_registerProtoWithId_(state, self, protoId);
 
 	{


### PR DESCRIPTION
Don't print unnecessary message when using Regex addon (https://github.com/stevedekorte/io/issues/338)

Either `IoBoxInit.c` has been removed or it's generated after OpenGL addon compilation. In any case this file is not needed to make OpenGL to work.