### PR TITLE
Remove trailing ") from end of doc lines

### DIFF
--- a/addons/Rational/io/Rational.io
+++ b/addons/Rational/io/Rational.io
@@ -23,7 +23,7 @@ Rational := Object clone do(
 	//doc Rational setDenominator(aNumber) Sets the denominator. Returns self.	
 	denominator ::= 0
 
-	//doc Rational with(aNumerator, aDenominator) Convenience constructor. Returns a new Rational number whose numerator and denominator are represented by the arguments aNumerator and aDenominator respectively.")
+	//doc Rational with(aNumerator, aDenominator) Convenience constructor. Returns a new Rational number whose numerator and denominator are represented by the arguments aNumerator and aDenominator respectively.
 	with := method(n, d,
 		if(d < 0,
 			n = -n
@@ -161,6 +161,6 @@ Number do(
 		b gcd(self % b)
 	)
 
-	//doc Rational asRational Converts the number to a Rational number. CAVEAT: Numbers in Io are floating point entities, which means since they are imprecise, this conversion may yield values not expected.")
+	//doc Rational asRational Converts the number to a Rational number. CAVEAT: Numbers in Io are floating point entities, which means since they are imprecise, this conversion may yield values not expected.
 	asRational := method(Rational with(self, 1))
 )

--- a/libs/iovm/io/A2_Object.io
+++ b/libs/iovm/io/A2_Object.io
@@ -1,5 +1,5 @@
 /*
-//metadoc nil description nil is a singleton object that is used as a placeholder and to mean false in Io.")
+//metadoc nil description nil is a singleton object that is used as a placeholder and to mean false in Io.
 
 nil do(
 	//doc nil clone returns self since nil is a singleton.

--- a/libs/iovm/io/B_Sequence.io
+++ b/libs/iovm/io/B_Sequence.io
@@ -150,7 +150,7 @@ Sequence do(
 			r
 	)
 
-	//doc Sequence prependSeq(object1, object2, ...) Prepends given objects asString in reverse order to the receiver.  Returns self.")
+	//doc Sequence prependSeq(object1, object2, ...) Prepends given objects asString in reverse order to the receiver.  Returns self.
 	prependSeq := method(self atInsertSeq(0, call evalArgs join); self)
 
 	//doc Sequence itemCopy Returns a new sequence containing the items from the receiver.
@@ -179,7 +179,7 @@ Sequence do(
 	//doc Sequence reverse Reverses the ordering of all the items of the receiver. Returns copy of receiver.
 	reverse := method(self itemCopy reverseInPlace)
 
-	//doc Sequence asHex Returns a hex string for the receiving sequence, e.g., \"abc\" asHex -> \"616263\".")
+	//doc Sequence asHex Returns a hex string for the receiving sequence, e.g., \"abc\" asHex -> \"616263\".
 	asHex := method(
 		r := Sequence clone
 		self foreach(c, r appendSeq(c asHex))


### PR DESCRIPTION
I believe these are leftover from previous doc annotation, right? They show up in the HTML reference documentation. Please review, thank you.