### PR TITLE
ObjcBridge: use idiomatic library detection in CMakeLists.txt

### DIFF
--- a/addons/ObjcBridge/CMakeLists.txt
+++ b/addons/ObjcBridge/CMakeLists.txt
@@ -40,9 +40,11 @@ set(SRCS
 set(CMAKE_EXE_LINKER_FLAGS "-framework AppKit")
 
 # Now build the shared library
+find_library(FOUNDATION Foundation)
+find_library(APPKIT AppKit)
 add_library(IoObjcBridge SHARED ${SRCS})
-add_dependencies(IoObjcBridge iovmall Foundation IoMD5 IoYajl IoBox IoSocket IoBlowfish IoSystemCall)
-target_link_libraries(IoObjcBridge iovmall ${ObjcBridge_LIBRARY} IoMD5 IoYajl IoBox IoSocket IoBlowfish IoSystemCall /System/Library/Frameworks/Foundation.framework/Versions/C/Foundation /System/Library/Frameworks/AppKit.framework/Versions/C/AppKit)
+add_dependencies(IoObjcBridge iovmall IoMD5 IoYajl IoBox IoSocket IoBlowfish IoSystemCall)
+target_link_libraries(IoObjcBridge iovmall ${ObjcBridge_LIBRARY} IoMD5 IoYajl IoBox IoSocket IoBlowfish IoSystemCall ${FOUNDATION} ${APPKIT})
 
 # Install the addon to our global addons hierarchy.
 install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR} DESTINATION lib/io/addons)


### PR DESCRIPTION
Fixes #379.

The current `CMakeLists.txt` in ObjcBridge produces a warning when used with newer versions of CMake.

Here's the warning I get when building Io with `cmake` 3.10.2 on macOS 10.13.3.

```
CMake Warning (dev) at addons/ObjcBridge/CMakeLists.txt:44 (add_dependencies):
  Policy CMP0046 is not set: Error on non-existent dependency in
  add_dependencies.  Run "cmake --help-policy CMP0046" for policy details.
  Use the cmake_policy command to set the policy and suppress this warning.

  The dependency target "Foundation" of target "IoObjcBridge" does not exist.
This warning is for project developers.  Use -Wno-dev to suppress it.
```

I think this is because it declares a dependency on `Foundation`, which isn't defined.

This PR changes `addons/ObjcBridge/CMakeLists.txt` to use a more idiomatic library detection and avoid what I think is a bogus dependency declaration. It does not change the behavior of the compiled `io` or addons (I think).

----

When testing ObjcBridge with this change, I get an error in the tests for the addon.

```
$ _build/binaries/io ../addons/ObjcBridge/samples/objc2ioTest.io

  Exception: Failed to load Addon ObjcBridge - Addon ObjcBridge depends on Addon Box
Socket
SystemCall
 but Addon Box
Socket
SystemCall
 cannot be found.
  ---------
  Object ObjcBridge                    objc2ioTest.io 1
  CLI doFile                           Z_CLI.io 140
  CLI run                              IoState_runCLI() 1
```

But I don't think this is a regression, because I get the exact same error when building from `master` (at commit ba2c9d95f9f9a01025a23e46dcd1077a76a200a7).