### PR TITLE
ObjcBridge addon: check YAJL dependency

### DIFF
--- a/addons/ObjcBridge/CMakeLists.txt
+++ b/addons/ObjcBridge/CMakeLists.txt
@@ -2,6 +2,12 @@
 if(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
 # Builds the ObjcBridge addon
 
+# This addon depends on the Yajl addon, which will only be built if the YAJL
+# lib was found. Skip build if missing. (This is hacky.)
+
+find_package(Yajl 2)
+if(YAJL_FOUND)
+
 # Create the _build bundle hierarchy if needed.
 make_build_bundle(_build)
 
@@ -47,5 +53,10 @@ target_link_libraries(IoObjcBridge iovmall ${ObjcBridge_LIBRARY} IoMD5 IoYajl Io
 # Install the addon to our global addons hierarchy.
 install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR} DESTINATION lib/io/addons)
 install(DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/_build DESTINATION lib/io/addons/ObjcBridge)
+
+else(YAJL_FOUND)
+  message("YAJL was not found; not building ObjcBridge addon")
+endif(YAJL_FOUND)
+
 endif(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
 


### PR DESCRIPTION
Fixes #279.

Right now, if `yajl` is not installed on the system, the Yajl addon will skip building, but the ObjcBridge addon, which depends on the Yajl addon, will still attempt to build, and you'll end up with a link error like this.

```
[ 72%] Linking C shared library _build/dll/libIoObjcBridge.dylib
ld: library not found for -lIoYajl
clang: error: linker command failed with exit code 1 (use -v to see invocation)
make[2]: *** [addons/ObjcBridge/_build/dll/libIoObjcBridge.dylib] Error 1
make[1]: *** [addons/ObjcBridge/CMakeFiles/IoObjcBridge.dir/all] Error 2
```

That's not a very helpful message, and it breaks the build.

This PR has the ObjcBridge addon check for `yajl`, and skip building if `yajl` is not installed, so you still get a successful build, just without the ObjcBridge addon. A message about this is emitted at `cmake` time.

```
YAJL was not found; not building ObjcBridge addon
```

It would probably be nicer to express this as a dependency on the `IoYajl` addon instead of `yajl` itself, but I don't see an easy way to do that with CMake. But I'm no CMake expert.

Should probably check for other library dependencies in the same way.