### PR TITLE
CMakeLists: make this a plain C project

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,7 +32,7 @@ endif()
 	
 # Project name, this gets prefixed to a bunch of stuff under the hood. No
 # spaces, or anything silly like that please.
-project(IoLanguage)
+project(IoLanguage C)
 
 # Default config when building with gcc variants
 IF(CMAKE_COMPILER_IS_GNUCC OR (CMAKE_C_COMPILER_ID MATCHES "Clang"))


### PR DESCRIPTION
Fixes #165.

This tells CMake that Io is a C-only project, and turns off the requirement
for a C++ compiler. This supports building on systems which have a C compiler
but not a C++ compiler.

Builds and tests correctly on my system (macOS 10.13.3, Xcode 9.2).

```
$ _build/binaries/io ../libs/iovm/tests/correctness/run.io
......................................................................
......................................................................
......................................................................
...................
----------------------------------------------------------------------
Ran 229 tests in 1.1128709999999999s

OK                                                                 run
```
