### PR TITLE
Unit tests: display run time rounded to milliseconds

### DIFF
--- a/libs/iovm/io/UnitTest.io
+++ b/libs/iovm/io/UnitTest.io
@@ -92,9 +92,11 @@ to run and values - lists of test slots theese UnitTests provide.*/
     )
 
     printSummary := method(
+        // Round run time to milliseconds
+        runtimeForDisplay := ((runtime * 1000) - (runtime * 1000 % 1)) / 1000
         "-" repeated(width) println
         ("Ran " .. testCount .. " test" .. if(testCount != 1, "s", "") .. \
-         " in " .. runtime .. "s\n") println
+         " in " .. runtimeForDisplay .. "s\n") println
 
         result := if(exceptions isNotEmpty,
             "FAILED (failures #{exceptions size})" interpolate


### PR DESCRIPTION
This is a request for a minor aesthetic enhancement.

This PR has the unit test runner display the run time rounded to milliseconds. I think this is desirable because higher precision timings are unlikely to be significant (i.e., you have typical noise of +/- 1 millisecond or greater) and this makes the run time display a constant column width. I think this improves readability.

Before:

```
$ _build/binaries/io ../libs/iovm/tests/correctness/run.io
......................................................................
......................................................................
......................................................................
...................
----------------------------------------------------------------------
Ran 229 tests in 1.151899s
[...]
...................
----------------------------------------------------------------------
Ran 229 tests in 1.0926309999999999s
```

After:

```
$ _build/binaries/io ../libs/iovm/tests/correctness/run.io
......................................................................
......................................................................
......................................................................
...................
----------------------------------------------------------------------
Ran 229 tests in 1.125s
```

