### PR TITLE
addons/OpenGL: More concise GLUT deprecation warning

### DIFF
--- a/addons/OpenGL/CMakeLists.txt
+++ b/addons/OpenGL/CMakeLists.txt
@@ -47,6 +47,14 @@ if(OPENGL_FOUND AND OPENGL_GLU_FOUND AND GLUT_FOUND AND ((GLUT_Xmu_LIBRARY AND G
 
 	# Now build the shared library
 	add_library(IoOpenGL SHARED ${SRCS})
+
+    # GLUT is deprecated on macOS 10.6 and later. Make the deprecation warnings
+    # more concise
+    if (APPLE)
+        message(WARNING "GLUT is deprecated on macOS 10.6")
+        target_compile_options(IoOpenGL PUBLIC -Wno-deprecated)
+    endif (APPLE)
+    
   add_dependencies(IoOpenGL iovmall)
   target_link_libraries(IoOpenGL iovmall ${OPENGL_LIBRARIES} ${GLUT_LIBRARIES})
 


### PR DESCRIPTION
GLUT is deprecated on macOS 10.6 and later. This causes clang to
spam deprecation warnings on every GLUT function call by default.

This PR silences those warnings and replaces them with a
single cmake-time warning.

Before:

Lots of warnings in the `make` output that look like this:

```
/Users/janke/local/repos/io/addons/OpenGL/source/IoGLU.c:471:2: warning: 'gluQuadricTexture'
      is deprecated: first deprecated in macOS 10.9 [-Wdeprecated-declarations]
        gluQuadricTexture(IoGLUQuadric_quadric(q), t);
        ^
/System/Library/Frameworks/OpenGL.framework/Headers/glu.h:286:13: note: 'gluQuadricTexture'
      has been explicitly marked deprecated here
extern void gluQuadricTexture (GLUquadric* quad, GLboolean texture) OPENGL_DEPRECATED...
            ^
/Users/janke/local/repos/io/addons/OpenGL/source/IoGLU.c:482:2: warning: 'gluSphere' is
      deprecated: first deprecated in macOS 10.9 [-Wdeprecated-declarations]
        gluSphere(IoGLUQuadric_quadric(q), radius, slices, stacks);
        ^
/System/Library/Frameworks/OpenGL.framework/Headers/glu.h:288:13: note: 'gluSphere' has been
      explicitly marked deprecated here
extern void gluSphere (GLUquadric* quad, GLdouble radius, GLint slices, GLint stacks...
            ^
/Users/janke/local/repos/io/addons/OpenGL/source/IoGLU.c:486:20: warning: 'GLUquadricObj' is
      deprecated: first deprecated in macOS 10.9 [-Wdeprecated-declarations]
void gluRoundedBox(GLUquadricObj *quadric, GLdouble w, GLdouble h, GLdouble r, GLint slices)
                   ^
[...]
```

Full example build log here: https://gist.github.com/apjanke/64e857caa1b66a2d87e3bd9ac4857a31

After:

Those warnings go away, replaced by a single `cmake`-time warning like this.

```
CMake Warning at addons/OpenGL/CMakeLists.txt:22 (message):
  GLUT is deprecated on macOS 10.6
```

This saves about a thousand lines of warning messages from the build output.

```
$ wc -l build-head/build.out
    1791 build-head/build.out
$ wc -l build-concise/build.out
     780 build-concise/build.out
```

I think this is worthwhile; a single warning about GLUT deprecation is sufficient, and these warnings make the current build log pretty unreadable.

CAVEAT: I *think* the `add_compile_options(-Wno-deprecated)` is scoped to the subdirectory by CMake, which is how it should be. If I'm wrong and it actually takes effect globally, some other mechanism might be needed.