### PR TITLE
fix EditLine warnings under clang

### DIFF
--- a/addons/EditLine/source/IoEditLine.c
+++ b/addons/EditLine/source/IoEditLine.c
@@ -56,7 +56,7 @@ IoEditLine *IoEditLine_proto(void *state)
 
 	el_source(DATA(self)->editline, NULL);
 
-	IoState_registerProtoWithFunc_((IoState *)state, self, IoEditLine_proto);
+	IoState_registerProtoWithFunc_((IoState *)state, self, (char *) IoEditLine_proto);
 
 	IoObject_addMethodTable_(self, methodTable);
 

--- a/libs/iovm/source/IoState.h
+++ b/libs/iovm/source/IoState.h
@@ -175,6 +175,7 @@ IOVM_API void IoState_init(IoState *self);
 void IoState_setupQuickAccessSymbols(IoState *self);
 void IoState_setupCachedMessages(IoState *self);
 void IoState_setupSingletons(IoState *self);
+void IoState_registerProtoWithFunc_(IoState *self, IoObject *proto, const char *v);
 
 // setup tags
 


### PR DESCRIPTION
This fixes a couple warnings encountered when compiling under recent `clang` on macOS. (macOS 10.13.3 and Xcode 9.2, for me here.)

Before:

```
[ 53%] Building C object addons/EditLine/CMakeFiles/IoEditLine.dir/source/IoEditLine.c.o
/Users/janke/tmp/build-io/io/addons/EditLine/source/IoEditLine.c:59:2: warning: implicit declaration of function 'IoState_registerProtoWithFunc_' is invalid in C99 [-Wimplicit-function-declaration]
        IoState_registerProtoWithFunc_((IoState *)state, self, IoEditLine_proto);
        ^
1 warning generated.

[ 53%] Generating ../../../addons/EditLine/source/IoEditLineInit.c
Scanning dependencies of target IoEditLine
[ 53%] Building C object addons/EditLine/CMakeFiles/IoEditLine.dir/source/IoEditLine.c.o
/Users/janke/tmp/build-io/io/addons/EditLine/source/IoEditLine.c:59:57: warning: incompatible pointer types passing 'IoEditLine *(void *)' (aka 'struct CollectorMarker *(void *)') to parameter of type 'const char *' [-Wincompatible-pointer-types]
        IoState_registerProtoWithFunc_((IoState *)state, self, IoEditLine_proto);
                                                               ^~~~~~~~~~~~~~~~
/Users/janke/tmp/build-io/io/libs/iovm/source/IoState.h:178:81: note: passing argument to parameter 'v' here
void IoState_registerProtoWithFunc_(IoState *self, IoObject *proto, const char *v);
                                                                                ^
1 warning generated.
```

After:

```
[ 53%] Building C object addons/EditLine/CMakeFiles/IoEditLine.dir/source/IoEditLine.c.o
[ 53%] Building C object addons/EditLine/CMakeFiles/IoEditLine.dir/source/IoEditLineInit.c.o
[ 53%] Linking C shared library _build/dll/libIoEditLine.dylib
[ 53%] Built target IoEditLine
[ 53%] Generating ../../../addons/Facebook/source/IoFacebookInit.c
```

No behavioral changes to the code; this is just declarations and explicit typecasts to make the compiler happy.