### PR TITLE
Fix IoImage clang warnings

### DIFF
--- a/addons/Image/source/Image.h
+++ b/addons/Image/source/Image.h
@@ -145,6 +145,11 @@ IOIMAGE_API Image* Image_applyMinFilter(Image* self, int filterWidth, int filter
 IOIMAGE_API Image* Image_applyWeightedMedianFilter(Image* self, int filterWidth, int filterHeight, UArray* filter);
 IOIMAGE_API Image* Image_applyNonlinearGradientsFilter(Image* self);
 
+IOIMAGE_API void Image_bitMask(Image *self, int component, int bitMask);
+
+// internals
+
+int Image_isL8(Image *self);
 
 #endif
 

--- a/addons/Image/source/IoImage.c
+++ b/addons/Image/source/IoImage.c
@@ -687,7 +687,7 @@ IOIMAGE_API IoObject *IoImage_filterGauss(IoImage *self, IoObject *locals, IoMes
 	UArray_setItemType_(filter, CTYPE_int8_t);
 	UArray_setEncoding_(filter, CENCODING_NUMBER);
 	UArray_setSize_(filter, filterSize * filterSize);
-	int8_t *filterBytes = UArray_mutableBytes(filter);
+	int8_t *filterBytes = (int8_t *) UArray_mutableBytes(filter);
 	int x, y, x1, y1;
 	for(y = 0; y < filterSize; y++)
 	{
@@ -715,7 +715,7 @@ IOIMAGE_API IoObject *IoImage_filterUnsharpMask(IoImage *self, IoObject *locals,
 	UArray_setItemType_(filter, CTYPE_int8_t);
 	UArray_setEncoding_(filter, CENCODING_NUMBER);
 	UArray_setSize_(filter, 9);
-	int8_t *filterBytes = UArray_mutableBytes(filter);
+	int8_t *filterBytes = (int8_t *) UArray_mutableBytes(filter);
 	
 	filterBytes[0] = -1; filterBytes[1] = -1;    filterBytes[2] = -1;
 	filterBytes[3] = -1; filterBytes[4] = a + 8; filterBytes[5] = -1;
@@ -739,7 +739,7 @@ IOIMAGE_API IoObject *IoImage_filterSobel(IoImage *self, IoObject *locals, IoMes
 	UArray_setItemType_(filter, CTYPE_int8_t);
 	UArray_setEncoding_(filter, CENCODING_NUMBER);
 	UArray_setSize_(filter, 9);
-	int8_t *filterBytes = UArray_mutableBytes(filter);
+	int8_t *filterBytes = (int8_t *) UArray_mutableBytes(filter);
 	int i;
 	for(i = 0; i < 8; i++)
 	{
@@ -764,7 +764,7 @@ IOIMAGE_API IoObject *IoImage_filterKirsch(IoImage *self, IoObject *locals, IoMe
 	UArray_setItemType_(filter, CTYPE_int8_t);
 	UArray_setEncoding_(filter, CENCODING_NUMBER);
 	UArray_setSize_(filter, 9);
-	int8_t *filterBytes = UArray_mutableBytes(filter);
+	int8_t *filterBytes = (int8_t *) UArray_mutableBytes(filter);
 	int i;
 	for(i = 0; i < 8; i++)
 	{


### PR DESCRIPTION
This PR fixes warnings issued by current `clang` by adding a function prototype and making some casts explicit.

I believe this does not change any current behavior; it just makes it more explicit to make the compiler happy.

-------

In the `make` stage:

Before:

```
[ 58%] Building C object addons/Image/CMakeFiles/IoImage.dir/source/IoImage.c.o
/Users/janke/tmp/build-io/io/addons/Image/source/IoImage.c:339:22: warning: implicit declaration of function 'Image_isL8' is invalid in C99 [-Wimplicit-function-declaration]
        return IOBOOL(self, Image_isL8(DATA(self)->image));
                            ^
/Users/janke/tmp/build-io/io/addons/Image/source/IoImage.c:596:2: warning: implicit declaration of function 'Image_bitMask' is invalid in C99 [-Wimplicit-function-declaration]
        Image_bitMask(DATA(self)->image, component, 255); 
        ^
/Users/janke/tmp/build-io/io/addons/Image/source/IoImage.c:690:10: warning: initializing 'int8_t *' (aka 'signed char *') with an expression of type 'uint8_t *' (aka 'unsigned char *') converts between pointers to integer types with different sign [-Wpointer-sign]
        int8_t *filterBytes = UArray_mutableBytes(filter);
                ^             ~~~~~~~~~~~~~~~~~~~~~~~~~~~
/Users/janke/tmp/build-io/io/addons/Image/source/IoImage.c:718:10: warning: initializing 'int8_t *' (aka 'signed char *') with an expression of type 'uint8_t *' (aka 'unsigned char *') converts between pointers to integer types with different sign [-Wpointer-sign]
        int8_t *filterBytes = UArray_mutableBytes(filter);
                ^             ~~~~~~~~~~~~~~~~~~~~~~~~~~~
/Users/janke/tmp/build-io/io/addons/Image/source/IoImage.c:742:10: warning: initializing 'int8_t *' (aka 'signed char *') with an expression of type 'uint8_t *' (aka 'unsigned char *') converts between pointers to integer types with different sign [-Wpointer-sign]
        int8_t *filterBytes = UArray_mutableBytes(filter);
                ^             ~~~~~~~~~~~~~~~~~~~~~~~~~~~
/Users/janke/tmp/build-io/io/addons/Image/source/IoImage.c:767:10: warning: initializing 'int8_t *' (aka 'signed char *') with an expression of type 'uint8_t *' (aka 'unsigned char *') converts between pointers to integer types with different sign [-Wpointer-sign]
        int8_t *filterBytes = UArray_mutableBytes(filter);
                ^             ~~~~~~~~~~~~~~~~~~~~~~~~~~~
6 warnings generated.]
```

After:

```
[ 57%] Generating ../../../addons/Image/source/IoImageInit.c
Scanning dependencies of target IoImage
[ 57%] Building C object addons/Image/CMakeFiles/IoImage.dir/source/Image.c.o
[ 57%] Building C object addons/Image/CMakeFiles/IoImage.dir/source/JPGImage.c.o
```

Tested on macOS 10.13.3 with Xcode 9.2.