### PR TITLE
Libxml2: fix clang warning about incompatible pointer types

### DIFF
--- a/addons/Libxml2/source/IoXmlReader.c
+++ b/addons/Libxml2/source/IoXmlReader.c
@@ -41,7 +41,7 @@ IoXmlReader *IoXmlReader_proto(void *state)
 
 	IoObject_setDataPointer_(self, calloc(1, sizeof(IoXmlReaderData)));
 
-	IoState_registerProtoWithFunc_(state, self, IoXmlReader_proto);
+	IoState_registerProtoWithFunc_(state, self, (void *)IoXmlReader_proto);
 	IoMethodTable methodTable[] = {
 		{"parseFile", IoXmlReader_parseFile},
 		{"parseString", IoXmlReader_parseString},


### PR DESCRIPTION
Fixes a compiler warning issued by recent `clang` when compiling LibXml2.

Before:

```
[ 67%] Generating ../../../addons/Libxml2/source/IoLibxml2Init.c
Scanning dependencies of target IoLibxml2
[ 68%] Building C object addons/Libxml2/CMakeFiles/IoLibxml2.dir/source/IoXmlReader.c.o
/Users/janke/local/repos/io/addons/Libxml2/source/IoXmlReader.c:44:46: warning: incompatible pointer types passing 'IoXmlReader *(void *)' (aka 'struct CollectorMarker *(void *)') to parameter of type 'const char *' [-Wincompatible-pointer-types]
        IoState_registerProtoWithFunc_(state, self, IoXmlReader_proto);
                                                    ^~~~~~~~~~~~~~~~~
/Users/janke/local/repos/io/libs/iovm/source/IoState.h:178:81: note: passing argument to parameter 'v' here
void IoState_registerProtoWithFunc_(IoState *self, IoObject *proto, const char *v);
                                                                                ^
1 warning generated.
[ 68%] Building C object addons/Libxml2/CMakeFiles/IoLibxml2.dir/source/IoXmlWriter.c.o
[ 68%] Building C object addons/Libxml2/CMakeFiles/IoLibxml2.dir/source/IoLibxml2Init.c.o
[ 68%] Linking C shared library _build/dll/libIoLibxml2.dylib
[ 68%] Built target IoLibxml2
```

After:

```
[ 67%] Generating ../../../addons/Libxml2/source/IoLibxml2Init.c
Scanning dependencies of target IoLibxml2
[ 68%] Building C object addons/Libxml2/CMakeFiles/IoLibxml2.dir/source/IoXmlReader.c.o
[ 68%] Building C object addons/Libxml2/CMakeFiles/IoLibxml2.dir/source/IoXmlWriter.c.o
[ 68%] Building C object addons/Libxml2/CMakeFiles/IoLibxml2.dir/source/IoLibxml2Init.c.o
[ 68%] Linking C shared library _build/dll/libIoLibxml2.dylib
[ 68%] Built target IoLibxml2
```

--------

Side note: I'm wondering if the [`IoState_registerProtoWithFunc_` signature](https://github.com/stevedekorte/io/blob/cfecb68f91af48baeeb050c96d3b6de78cfe1b9d/libs/iovm/source/IoState.h#L178):

```
void IoState_registerProtoWithFunc_(IoState *self, IoObject *proto, const char *v)
```

shouldn't use `const void *v` instead? It's not treating the pointer as a string/byte buffer, and `IoState_registerProtoWithId_` is converting to `void *` internally to use with `PointerHash`. That is, something like this?

```
void IoState_registerProtoWithFunc_(IoState *self, IoObject *proto, const void *v)
```
