### PR TITLE
SGML addon: silence compiler warnings for libsgml

### DIFF
--- a/addons/SGML/source/libsgml-1.1.4/src/CMakeLists.txt
+++ b/addons/SGML/source/libsgml-1.1.4/src/CMakeLists.txt
@@ -31,8 +31,12 @@ endif(MSVC)
 # Our library!
 add_library(sgml STATIC ${SRCS})
 
+# Libsgml issues some warnings under clang. Since it's a third-party library, just
+# silence the warnings instead of modifying the source code.
+target_compile_options(sgml PUBLIC -Wno-pointer-sign)
+
 if(NOT WIN32)
-	set_target_properties(sgml PROPERTIES COMPILE_FLAGS "-fPIC")
+	target_compile_options(sgml PUBLIC -fPIC)
 endif(NOT WIN32)
 
 # Don't install it, we do that ourselves when the addon gets


### PR DESCRIPTION
Silences some `clang` warnings for the included libsgml-1.1.4 library.

Before:

```
Scanning dependencies of target sgml
[ 83%] Building C object addons/SGML/source/libsgml-1.1.4/src/CMakeFiles/sgml.dir/DomComment.c.o
[ 83%] Building C object addons/SGML/source/libsgml-1.1.4/src/CMakeFiles/sgml.dir/DomDocument.c.o
[ 83%] Building C object addons/SGML/source/libsgml-1.1.4/src/CMakeFiles/sgml.dir/DomElement.c.o
[ 84%] Building C object addons/SGML/source/libsgml-1.1.4/src/CMakeFiles/sgml.dir/DomNode.c.o
[ 84%] Building C object addons/SGML/source/libsgml-1.1.4/src/CMakeFiles/sgml.dir/DomNodeList.c.o
[ 84%] Building C object addons/SGML/source/libsgml-1.1.4/src/CMakeFiles/sgml.dir/DomText.c.o
[ 84%] Building C object addons/SGML/source/libsgml-1.1.4/src/CMakeFiles/sgml.dir/SgmlExtensionHtml.c.o
[ 85%] Building C object addons/SGML/source/libsgml-1.1.4/src/CMakeFiles/sgml.dir/SgmlExtensionXml.c.o
[ 85%] Building C object addons/SGML/source/libsgml-1.1.4/src/CMakeFiles/sgml.dir/SgmlParser.c.o
[ 85%] Building C object addons/SGML/source/libsgml-1.1.4/src/CMakeFiles/sgml.dir/Variant.c.o
/Users/janke/local/repos/io/addons/SGML/source/libsgml-1.1.4/src/Variant.c:166:43: warning: passing 'const char *' to parameter of type 'const unsigned char *' converts between pointers to integer types with different sign [-Wpointer-sign]
                                        value->binary = _variantBase64Decode(string, strlen(string), &value->length);
                                                                             ^~~~~~
/Users/janke/local/repos/io/addons/SGML/source/libsgml-1.1.4/src/Variant.c:14:49: note: passing argument to parameter 'src' here
char *_variantBase64Decode(const unsigned char *src, unsigned long srcLength, unsigned long *outLength);
                                                ^
/Users/janke/local/repos/io/addons/SGML/source/libsgml-1.1.4/src/Variant.c:166:20: warning: assigning to 'unsigned char *' from 'char *' converts between pointers to integer types with different sign [-Wpointer-sign]
                                        value->binary = _variantBase64Decode(string, strlen(string), &value->length);
                                                      ^ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
2 warnings generated.
[ 86%] Linking C static library ../../../_build/dll/libsgml.a
[ 86%] Built target sgml
```

After:

```
Scanning dependencies of target sgml
[ 83%] Building C object addons/SGML/source/libsgml-1.1.4/src/CMakeFiles/sgml.dir/DomComment.c.o
[ 83%] Building C object addons/SGML/source/libsgml-1.1.4/src/CMakeFiles/sgml.dir/DomDocument.c.o
[ 83%] Building C object addons/SGML/source/libsgml-1.1.4/src/CMakeFiles/sgml.dir/DomElement.c.o
[ 84%] Building C object addons/SGML/source/libsgml-1.1.4/src/CMakeFiles/sgml.dir/DomNode.c.o
[ 84%] Building C object addons/SGML/source/libsgml-1.1.4/src/CMakeFiles/sgml.dir/DomNodeList.c.o
[ 84%] Building C object addons/SGML/source/libsgml-1.1.4/src/CMakeFiles/sgml.dir/DomText.c.o
[ 84%] Building C object addons/SGML/source/libsgml-1.1.4/src/CMakeFiles/sgml.dir/SgmlExtensionHtml.c.o
[ 85%] Building C object addons/SGML/source/libsgml-1.1.4/src/CMakeFiles/sgml.dir/SgmlExtensionXml.c.o
[ 85%] Building C object addons/SGML/source/libsgml-1.1.4/src/CMakeFiles/sgml.dir/SgmlParser.c.o
[ 85%] Building C object addons/SGML/source/libsgml-1.1.4/src/CMakeFiles/sgml.dir/Variant.c.o
[ 86%] Linking C static library ../../../_build/dll/libsgml.a
[ 86%] Built target sgml
```