### PR TITLE
SHA1 addon: fix clang compiler warning about pointer signedness

### DIFF
--- a/addons/SHA1/source/IoSHA1.c
+++ b/addons/SHA1/source/IoSHA1.c
@@ -139,7 +139,7 @@ IoObject *IoSHA1_hmac(IoSHA1 *self, IoObject *locals, IoMessage *m)
 		IOSEQ_BYTES(inSeq), IOSEQ_LENGTH(inSeq), 
 		(void *)resbuf);
 	if(ok != 0) return IONIL(self);
-	return IOSEQ(resbuf, 20);
+	return IOSEQ((unsigned char *) resbuf, 20);
 
 }
 


### PR DESCRIPTION
Fixes a `clang` warning in the SHA1 addon, by explicitly casting the input to `IOSEQ(...)` in the same manner that other `IOSEQ` calls do.

Before:
```
Scanning dependencies of target IoSHA1
[ 88%] Building C object addons/SHA1/CMakeFiles/IoSHA1.dir/source/sha1.c.o
[ 88%] Building C object addons/SHA1/CMakeFiles/IoSHA1.dir/source/hmac.c.o
[ 88%] Building C object addons/SHA1/CMakeFiles/IoSHA1.dir/source/IoSHA1.c.o
/Users/janke/local/repos/io/addons/SHA1/source/IoSHA1.c:142:15: warning: passing 'char [20]' to parameter of type 'const unsigned char *' converts between pointers to integer types with different sign [-Wpointer-sign]
        return IOSEQ(resbuf, 20);
                     ^~~~~~
/Users/janke/local/repos/io/libs/iovm/source/IoSeq.h:24:73: note: expanded from macro 'IOSEQ'
#define IOSEQ(data, size)  IoSeq_newWithData_length_((IoState*)IOSTATE, data, size)
                                                                        ^~~~
/Users/janke/local/repos/io/libs/iovm/source/IoSeq.h:61:77: note: passing argument to parameter 's' here
IOVM_API IoSeq *IoSeq_newWithData_length_(void *state, const unsigned char *s, size_t length);
                                                                            ^
1 warning generated.
[ 89%] Building C object addons/SHA1/CMakeFiles/IoSHA1.dir/source/IoSHA1Init.c.o
[ 89%] Linking C shared library _build/dll/libIoSHA1.dylib
[ 89%] Built target IoSHA1
```

After:

```
Scanning dependencies of target IoSHA1
[ 88%] Building C object addons/SHA1/CMakeFiles/IoSHA1.dir/source/sha1.c.o
[ 88%] Building C object addons/SHA1/CMakeFiles/IoSHA1.dir/source/hmac.c.o
[ 88%] Building C object addons/SHA1/CMakeFiles/IoSHA1.dir/source/IoSHA1.c.o
[ 89%] Building C object addons/SHA1/CMakeFiles/IoSHA1.dir/source/IoSHA1Init.c.o
[ 89%] Linking C shared library _build/dll/libIoSHA1.dylib
[ 89%] Built target IoSHA1
```

-------

Testing:

The SHA1 addon's test fails under this PR.

```
$ _build/binaries/io ../addons/SHA1/tests/correctness/run.io
E
======================================================================
FAIL: SHA1Test testBasic
----------------------------------------------------------------------

  Exception: SHA1Test does not respond to 'SHA1'
  ---------
  SHA1Test SHA1                        SHA1Test.io 9
  SHA1Test testBasic                   doString 1

----------------------------------------------------------------------
Ran 1 test in 0s

FAILED (failures 1)                                           SHA1Test
```

But I don't think that's a regression or related to this change. I get the same error when running the SHA1 test off of `master`.