### PR TITLE
Python addon: make Python dependency optional

### DIFF
--- a/addons/Python/CMakeLists.txt
+++ b/addons/Python/CMakeLists.txt
@@ -4,7 +4,7 @@
 # Builds the Python addon
 
 # Find curses
-find_package(PythonLibs 3.3 REQUIRED)
+find_package(PythonLibs 3.3)
 
 # Create the _build bundle hierarchy if needed.
 make_build_bundle(_build)


### PR DESCRIPTION
The Python addon declares a REQUIRED dependency on the Python libraries. This means that if they're not found, the entire build will be aborted, instead of just skipping the Python addin.

This PR removes the REQUIRED option. This will allow it to skip the Python plugin and still complete the rest of the build on a system where Python could not be located, instead of aborting the whole build.