### PR TITLE
Fix Date#setDay validation for all 30-day months

### DIFF
--- a/libs/iovm/source/IoDate.c
+++ b/libs/iovm/source/IoDate.c
@@ -275,7 +275,7 @@ IO_METHOD(IoDate, setDay) {
         } else {
             IOASSERT(v >= 1 && v <= 28, "day must be within range 1-28");
         }
-    } else if (month == 11) {
+    } else if (month == 4 || month == 6 || month == 9 || month == 11) {
         IOASSERT(v >= 1 && v <= 30, "day must be within range 1-30");
     } else if (month == 12) {
         IOASSERT(v >= 1 && v <= 31, "day must be within range 1-31");

--- a/libs/iovm/tests/correctness/DateTest.io
+++ b/libs/iovm/tests/correctness/DateTest.io
@@ -79,5 +79,16 @@ DateTest := UnitTest clone do(
 		//testString("%x") #%x is locale dependent
 		testString("%y")
 	)
+
+	// Regression: setDay must reject day 31 in 30-day months (Apr/Jun/Sep/Nov).
+	// Previously only November was checked; April/June/September could accept 31 incorrectly.
+	testSetDayThirtyDayMonths := method(
+		assertRaisesException(Date clone setMonth(4) setDay(31))
+		assertRaisesException(Date clone setMonth(6) setDay(31))
+		assertRaisesException(Date clone setMonth(9) setDay(31))
+		assertRaisesException(Date clone setMonth(11) setDay(31))
+	)
 )
+
+if(isLaunchScript, DateTest run, DateTest)
 


### PR DESCRIPTION
## Summary

`IoDate_setDay` only applied the 30-day guard to November (`month == 11`), so April, June, and September were not validated as 30-day months and could accept `setDay(31)` incorrectly.

## Changes

- Extend the same `1–30` day assertion to months 4, 6, 9, and 11 (calendar 30-day months).
- Add `DateTest` regression: `assertRaisesException` for `setDay(31)` in each of those months, plus `isLaunchScript` so `io DateTest.io` runs the suite.

## Testing

```bash
cd build && cmake --build .
./_build/binaries/io ../libs/iovm/tests/correctness/DateTest.io
```