### PR TITLE
Fix GCC 16 incompatible-pointer return in IoFile_readUArrayOfLength_

### DIFF
--- a/libs/iovm/source/IoFile.c
+++ b/libs/iovm/source/IoFile.c
@@ -868,7 +868,10 @@ UArray *IoFile_readUArrayOfLength_(IoFile *self, IoObject *locals,
     size_t length = IoMessage_locals_sizetArgAt_(m, locals, 0);
     UArray *ba = UArray_new();
     IoFile_assertOpen(self, locals, m);
-    if (IOSTATE->errorRaised) return IONIL(self);
+    if (IOSTATE->errorRaised) {
+        UArray_free(ba);
+        return NULL;
+    }
 
     UArray_readNumberOfItems_fromCStream_(ba, length, DATA(self)->stream);
 


### PR DESCRIPTION
## Problem

Reported in #498: the native VM fails to build with **GCC 16**, which promotes `-Wincompatible-pointer-types` to a hard error by default. The reporter worked around it with `CFLAGS=-Wno-error=incompatible-pointer-types`, but there's a genuine bug underneath.

`IoFile_readUArrayOfLength_` (`libs/iovm/source/IoFile.c`) returns `UArray *`, but its error path did:

```c
if (IOSTATE->errorRaised) return IONIL(self);
```

`IONIL(self)` expands to `IOSTATE->ioNil`, an `IoObject *`. Since `UArray` is a distinct basekit struct (not a `typedef` of `IoObject`), this is a real incompatible-pointer return.

It was also a **latent logic + leak bug**: both callers (`readBufferOfLength_`, `readStringOfLength_`) test the result for `NULL` to mean "return Nil". The non-NULL `ioNil` pointer would make a failed read look successful and then get passed to `IoSeq_newWithUArray_copy_`, and the freshly allocated `UArray` was leaked.

## Fix

Free the buffer and return `NULL`, matching the existing end-of-file path a few lines below.

I swept the rest of the tree for the same class of incompatible-pointer return; this was the only genuine one (other apparent hits return `IoObject`-typedef'd types like `IoMessage`/`IoNumber`, which are fine).

🤖 Generated with [Claude Code](https://claude.com/claude-code)