### PR TITLE
docs: update deadlinks to io guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -235,7 +235,7 @@ Any other relevant information
 ## 📚 Resources
 
 ### Documentation
-- [Official Guide](http://iolanguage.org/guide/guide.html)
+- [Official Guide](https://iolanguage.org/docs/Guide)
 - [API Reference](docs/reference/index.html)
 - Source code comments and examples
 

--- a/DEVELOPERS.md
+++ b/DEVELOPERS.md
@@ -165,7 +165,7 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for detailed guidelines.
 
 ## 📚 Resources
 
-- [Official Guide](http://iolanguage.org/guide/guide.html)
+- [Official Guide](https://iolanguage.org/docs/Guide)
 - [CONTRIBUTING.md](CONTRIBUTING.md) - Contribution guidelines
 - [README.md](README.md) - General information
 - `docs/` - API documentation

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # The Io Language
 
-_This is a reference for building and running Io. For a guide to the language itself, see <http://iolanguage.org/guide/guide.html>._
+_This is a reference for building and running Io. For a guide to the language itself, see <https://iolanguage.org/docs/Guide>._
 
 ## Contents
 


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the changes in this PR -->
Multiple markdown files still contain previously valid URLs to the io guides, but they've since moved and are now invalid, leading to 404s. This pr updates these deadlinks to the correct ones.

## Type of Change
<!-- Mark the relevant option with an "x" -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring

## Changes Made
<!-- List the main changes made in this PR -->
- Update links
- Newline at end of line
